### PR TITLE
Allow alternative MasterClient implementations

### DIFF
--- a/src/master_client.cc
+++ b/src/master_client.cc
@@ -4,7 +4,7 @@
 
 #include "utils.h"
 
-Status MasterClient::Connect(const std::string& address, int port) {
+Status RedisMasterClient::Connect(const std::string& address, int port) {
   redis_context_.reset(SyncConnect(address, port));
   return Status::OK();
 }
@@ -13,7 +13,7 @@ const char* MasterClient::WatermarkKey(Watermark w) const {
   return w == MasterClient::Watermark::kSnCkpt ? "_sn_ckpt" : "_sn_flushed";
 }
 
-Status MasterClient::GetWatermark(Watermark w, int64_t* val) const {
+Status RedisMasterClient::GetWatermark(Watermark w, int64_t* val) const {
   redisReply* reply = reinterpret_cast<redisReply*>(
       redisCommand(redis_context_.get(), "GET %s", WatermarkKey(w)));
   const std::string reply_str(reply->str, reply->len);  // Can be optimized
@@ -39,7 +39,7 @@ Status MasterClient::GetWatermark(Watermark w, int64_t* val) const {
   return Status::OK();
 }
 
-Status MasterClient::SetWatermark(Watermark w, int64_t new_val) {
+Status RedisMasterClient::SetWatermark(Watermark w, int64_t new_val) {
   const char* new_val_data = reinterpret_cast<const char*>(&new_val);
 
   redisReply* reply = reinterpret_cast<redisReply*>(
@@ -52,4 +52,13 @@ Status MasterClient::SetWatermark(Watermark w, int64_t new_val) {
 
   freeReplyObject(reply);
   return Status::OK();
+}
+
+Status RedisMasterClient::Head(std::string* address, int* port) {
+  CHECK(false) << "Not implemented";
+  return Status::NotSupported("Not implemented");
+}
+Status RedisMasterClient::Tail(std::string* address, int* port) {
+  CHECK(false) << "Not implemented";
+  return Status::NotSupported("Not implemented");
 }

--- a/src/master_client.h
+++ b/src/master_client.h
@@ -60,11 +60,11 @@ class MasterClient {
 
 class RedisMasterClient : public MasterClient {
  public:
-  virtual Status Connect(const std::string& address, int port) override;
-  virtual Status Head(std::string* address, int* port) override;
-  virtual Status Tail(std::string* address, int* port) override;
-  virtual Status GetWatermark(Watermark w, int64_t* val) const override;
-  virtual Status SetWatermark(Watermark w, int64_t new_val) override;
+  Status Connect(const std::string& address, int port) override;
+  Status Head(std::string* address, int* port) override;
+  Status Tail(std::string* address, int* port) override;
+  Status GetWatermark(Watermark w, int64_t* val) const override;
+  Status SetWatermark(Watermark w, int64_t new_val) override;
 
  private:
   std::unique_ptr<redisContext> redis_context_;

--- a/src/master_client.h
+++ b/src/master_client.h
@@ -52,8 +52,6 @@ class MasterClient {
  protected:
   const char* WatermarkKey(Watermark w) const;
 
-  std::unique_ptr<redisContext> redis_context_;
-
   static constexpr int64_t kSnCkptInit = 0;
   static constexpr int64_t kSnFlushedInit = 0;
 };
@@ -68,6 +66,7 @@ class RedisMasterClient : public MasterClient {
 
  private:
   std::unique_ptr<redisContext> redis_context_;
+
 };
 
 #endif  // CREDIS_MASTER_CLIENT_H_

--- a/tests/test.py
+++ b/tests/test.py
@@ -3,7 +3,7 @@ import unittest
 import uuid
 
 import redis
-import common
+from tests import common
 # This script should be run from within the credis/ directory
 
 _CLIENT_ID = str(uuid.uuid4())  # Used as the channel name receiving acks.


### PR DESCRIPTION
This lays the groundwork to add a master based on other services such as
etcd.

For context: I am in Ion's 262A this semester, working with Zongheng to implement fault-tolerance in the master service.