### PR TITLE
Support for node removal & node addition

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,2 @@
 BasedOnStyle: Google
-ColumnLimit: 80
 DerivePointerAlignment: false
-IndentCaseLabels: false
-PointerAlignment: Left
-SpaceAfterCStyleCast: true
-BinPackParameters: false

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ __pycache__
 *.log
 callgrind.out.*
 *.sw*
+
+*.csv

--- a/add.sh
+++ b/add.sh
@@ -1,5 +1,6 @@
-
 #!/bin/bash
+#
+# add.sh
 set -x
 
 MASTER_SERVER=${1:-127.0.0.1}
@@ -11,6 +12,13 @@ gcs_mode=${gcs_ckptflush}
 gcs_mode=${gcs_normal}
 
 function add() {
+    # pushd build
+    # make -j
+    # popd
+
+    # Master.
+    # ./redis/src/redis-server --loadmodule ./build/src/libmaster.so --port 6369 &> master.log &
+
     # Assume by default the master & 1 node are already running, at 6369, 6370, respectively.
     port=6370
     while true; do
@@ -23,7 +31,7 @@ function add() {
     done
     echo 'break!'
 
-    ./redis/src/redis-server --loadmodule ./build/src/libmember.so ${gcs_mode} --port $port --protected-mode no &> $port.log &
+    taskset 0x1 ./redis/src/redis-server --loadmodule ./build/src/libmember.so ${gcs_mode} --port $port --protected-mode no &> $port.log &
 
     sleep 0.5
     myip=$(curl ipinfo.io/ip)

--- a/add.sh
+++ b/add.sh
@@ -1,5 +1,6 @@
+
 #!/bin/bash
-set -ex
+set -x
 
 # Defaults to 1, or 1st arg if provided.
 # Master is assigned port 6369.  Chain node i gets port 6369+i.
@@ -12,16 +13,27 @@ gcs_mode=${gcs_ckptflush}
 gcs_mode=${gcs_normal}
 
 function setup() {
-    pushd build
-    make -j
-    popd
+    # pushd build
+    # make -j
+    # popd
 
     # Master.
-    ./redis/src/redis-server --loadmodule ./build/src/libmaster.so --port 6369 &> master.log &
+    # ./redis/src/redis-server --loadmodule ./build/src/libmaster.so --port 6369 &> master.log &
 
-    port=6369
+    # Assume by default the master & 1 node are already running, at 6369, 6370, respectively.
+    port=6370
+    while true; do
+        result=$(pgrep -a redis-server | grep $port)
+        if [[ -z ${result} ]]; then
+            echo 'breaking...'
+            break
+        fi
+        port=$(expr $port + 1)
+    done
+
+    echo 'break!'
+
     for i in $(seq 1 $NUM_NODES); do
-      port=$(expr $port + 1)
       #LD_PRELOAD=/usr/lib/libprofiler.so CPUPROFILE=/tmp/pprof-${i} \
       #  ./redis/src/redis-server --loadmodule ./build/src/libmember.so \
       #  --protected-mode no --port $port &> $port.log &
@@ -35,6 +47,8 @@ function setup() {
       # Have chain nodes connect to master.
       sleep 0.5
       ./redis/src/redis-cli -p $port MEMBER.CONNECT_TO_MASTER 127.0.0.1 6369
+
+      port=$(expr $port + 1)
     done
 }
 

--- a/add.sh
+++ b/add.sh
@@ -2,9 +2,7 @@
 #!/bin/bash
 set -x
 
-# Defaults to 1, or 1st arg if provided.
-# Master is assigned port 6369.  Chain node i gets port 6369+i.
-NUM_NODES=${1:-1}
+MASTER_SERVER=${1:-127.0.0.1}
 
 gcs_normal=0
 gcs_ckptonly=1
@@ -12,14 +10,7 @@ gcs_ckptflush=2
 gcs_mode=${gcs_ckptflush}
 gcs_mode=${gcs_normal}
 
-function setup() {
-    # pushd build
-    # make -j
-    # popd
-
-    # Master.
-    # ./redis/src/redis-server --loadmodule ./build/src/libmaster.so --port 6369 &> master.log &
-
+function add() {
     # Assume by default the master & 1 node are already running, at 6369, 6370, respectively.
     port=6370
     while true; do
@@ -30,27 +21,13 @@ function setup() {
         fi
         port=$(expr $port + 1)
     done
-
     echo 'break!'
 
-    for i in $(seq 1 $NUM_NODES); do
-      #LD_PRELOAD=/usr/lib/libprofiler.so CPUPROFILE=/tmp/pprof-${i} \
-      #  ./redis/src/redis-server --loadmodule ./build/src/libmember.so \
-      #  --protected-mode no --port $port &> $port.log &
+    ./redis/src/redis-server --loadmodule ./build/src/libmember.so ${gcs_mode} --port $port --protected-mode no &> $port.log &
 
-      # sudo cgexec -g memory:redisgroup ./redis/src/redis-server --loadmodule ./build/src/libmember.so ${gcs_mode} --port $port --protected-mode no &> $port.log &
-      ./redis/src/redis-server --loadmodule ./build/src/libmember.so ${gcs_mode} --port $port --protected-mode no &> $port.log &
-
-      sleep 0.5
-      myip=$(curl ipinfo.io/ip)
-      ./redis/src/redis-cli -p 6369 MASTER.ADD ${myip} $port
-
-      # Have chain nodes connect to master.
-      sleep 0.5
-      ./redis/src/redis-cli -p $port MEMBER.CONNECT_TO_MASTER 127.0.0.1 6369
-
-      port=$(expr $port + 1)
-    done
+    sleep 0.5
+    myip=$(curl ipinfo.io/ip)
+    ./redis/src/redis-cli -h ${MASTER_SERVER} -p 6369 MASTER.ADD ${myip} $port
 }
 
-setup
+add

--- a/add.sh
+++ b/add.sh
@@ -42,7 +42,8 @@ function setup() {
       ./redis/src/redis-server --loadmodule ./build/src/libmember.so ${gcs_mode} --port $port --protected-mode no &> $port.log &
 
       sleep 0.5
-      ./redis/src/redis-cli -p 6369 MASTER.ADD 127.0.0.1 $port
+      myip=$(curl ipinfo.io/ip)
+      ./redis/src/redis-cli -p 6369 MASTER.ADD ${myip} $port
 
       # Have chain nodes connect to master.
       sleep 0.5

--- a/add.sh
+++ b/add.sh
@@ -4,6 +4,7 @@
 set -x
 
 MASTER_SERVER=${1:-127.0.0.1}
+port=${2:-6371}  # Initial port to start trying.
 
 gcs_normal=0
 gcs_ckptonly=1
@@ -20,7 +21,6 @@ function add() {
     # ./redis/src/redis-server --loadmodule ./build/src/libmaster.so --port 6369 &> master.log &
 
     # Assume by default the master & 1 node are already running, at 6369, 6370, respectively.
-    port=6370
     while true; do
         result=$(pgrep -a redis-server | grep $port)
         if [ -z "${result}" ]; then

--- a/add.sh
+++ b/add.sh
@@ -24,7 +24,7 @@ function setup() {
     port=6370
     while true; do
         result=$(pgrep -a redis-server | grep $port)
-        if [[ -z ${result} ]]; then
+        if [ -z "${result}" ]; then
             echo 'breaking...'
             break
         fi

--- a/add.sh
+++ b/add.sh
@@ -34,7 +34,8 @@ function add() {
     taskset 0x1 ./redis/src/redis-server --loadmodule ./build/src/libmember.so ${gcs_mode} --port $port --protected-mode no &> $port.log &
 
     sleep 0.5
-    myip=$(curl ipinfo.io/ip)
+    # myip=$(curl ipinfo.io/ip)
+    myip=$(hostname -i)
     ./redis/src/redis-cli -h ${MASTER_SERVER} -p 6369 MASTER.ADD ${myip} $port
 }
 

--- a/bench-redis.sh
+++ b/bench-redis.sh
@@ -10,7 +10,7 @@ pkill -f redis_seqput_bench
 pkill -f credis_seqput_bench
 
 ssh -o StrictHostKeyChecking=no ubuntu@${SERVER} << EOF
-cd ~/credis-1
+cd ~/credis
 pkill -f redis-server
 sleep 2
 ./setup.sh 1

--- a/bench.sh
+++ b/bench.sh
@@ -27,30 +27,32 @@ popd
 #     done
 # done
 
-#for write_ratio in 1 ; do
-for write_ratio in 1 0.66 0.33 ; do
+for write_ratio in 1 ; do
+#for write_ratio in 1 0.66 0.33 ; do
 
-#     # Redis
-#     echo 'num_clients throughput latency' > redis-wr${write_ratio}.txt
-#     for num_clients in 64; do
-#         sleep 5
-#         ./bench-redis.sh $num_clients $write_ratio $SERVER
-#     done
+    # # Redis
+    # echo 'num_clients throughput latency' > redis-wr${write_ratio}.txt
+    # for num_clients in 32 28; do
+    #     sleep 5
+    #     ./bench-redis.sh $num_clients $write_ratio $SERVER
+    # done
 
     # Chain
-    for num_nodes in  2 1; do
+    for num_nodes in  1; do
+    #for num_nodes in  2 1; do
         echo 'num_clients throughput latency' > chain-${num_nodes}node-wr${write_ratio}.txt
 
       #  base=2
       #  limit=6
       #  for i in $(seq $limit -1 0); do
       #    num_clients=$(echo "$base^$i" | bc)
-        #for num_clients in 64; do
-        for num_clients in $(seq 64 -4 1); do
+        for num_clients in 1; do
+        # for num_clients in $(seq 32 -4 1); do
             sleep 5
             ./seqput.sh $num_clients $num_nodes $write_ratio $SERVER &
             wait
         done
       #done
     done
+
 done

--- a/bench.sh
+++ b/bench.sh
@@ -3,6 +3,8 @@ set -ex
 
 SERVER=${1:-127.0.0.1}
 NODE_ADD=${2:-""}
+NODE_KILL=${3:-""}
+N=${4:-""}
 
 pushd build
 make -j
@@ -39,7 +41,7 @@ for write_ratio in 1 ; do
     # done
 
     # Chain
-    for num_nodes in  1; do
+    for num_nodes in  2; do
     #for num_nodes in  2 1; do
         echo 'num_clients throughput latency' > chain-${num_nodes}node-wr${write_ratio}.txt
 
@@ -50,7 +52,7 @@ for write_ratio in 1 ; do
         for num_clients in 1; do
         # for num_clients in $(seq 32 -4 1); do
             sleep 5
-            ./seqput.sh $num_clients $num_nodes $write_ratio $SERVER $NODE_ADD &
+            ./seqput.sh $num_clients $num_nodes $write_ratio $SERVER $NODE_ADD $NODE_KILL $N &
             wait
         done
       #done

--- a/bench.sh
+++ b/bench.sh
@@ -2,6 +2,7 @@
 set -ex
 
 SERVER=${1:-127.0.0.1}
+NODE_ADD=${2:-""}
 
 pushd build
 make -j
@@ -49,7 +50,7 @@ for write_ratio in 1 ; do
         for num_clients in 1; do
         # for num_clients in $(seq 32 -4 1); do
             sleep 5
-            ./seqput.sh $num_clients $num_nodes $write_ratio $SERVER &
+            ./seqput.sh $num_clients $num_nodes $write_ratio $SERVER $NODE_ADD &
             wait
         done
       #done

--- a/distributed_bench.sh
+++ b/distributed_bench.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Usage: run on client server.
+
+set -ex
+
+HEAD_SERVER=${1:-127.0.0.1}
+TAIL_SERVER=${2:-127.0.0.1}
+NODE_ADD=${3:-""}
+NODE_KILL=${4:-""}
+N=${5:-""}
+
+pushd build; make -j; popd
+
+for write_ratio in 1 ; do
+    # Chain
+    for num_nodes in  2; do
+        echo 'num_clients throughput latency' > chain-${num_nodes}node-wr${write_ratio}.txt
+
+        for num_clients in 1; do
+
+            # Launch master & head.
+            ssh -o StrictHostKeyChecking=no ubuntu@${HEAD_SERVER} << EOF
+cd ~/credis
+pkill -f -9 redis-server
+sleep 2
+./setup.sh $num_nodes
+sleep 2
+EOF
+            # Launch tail.  We pass $HEAD_SERVER to setup.sh, which will skip master creation.
+            ssh -o StrictHostKeyChecking=no ubuntu@${TAIL_SERVER} << EOF
+cd ~/credis
+pkill -f -9 redis-server
+sleep 2
+./setup.sh $num_nodes $HEAD_SERVER
+sleep 2
+EOF
+
+            sleep 5
+            ./distributed_seqput.sh $num_clients $num_nodes $write_ratio \
+                                    $HEAD_SERVER $TAIL_SERVER $NODE_ADD $NODE_KILL $N &
+            wait
+        done
+    done
+
+done

--- a/distributed_bench.sh
+++ b/distributed_bench.sh
@@ -14,15 +14,14 @@ N=${5:-""}
 
 pushd build; make -j; popd
 
-for write_ratio in 1 ; do
+for write_ratio in 0.5 ; do
+    # for write_ratio in 1 ; do
     # Chain
     for num_nodes in  2; do
         echo 'num_clients throughput latency' > chain-${num_nodes}node-wr${write_ratio}.txt
 
-        # for num_clients in 2; do
-            # for num_clients in 32; do
-                # for num_clients in $(seq 64 -4 1); do
-                for num_clients in 32; do
+        for num_clients in 1; do
+                # for num_clients in 16; do
 
             ssh -o StrictHostKeyChecking=no ubuntu@${HEAD_SERVER} "pkill -f -9 redis-server; sleep 1" || true
             ssh -o StrictHostKeyChecking=no ubuntu@${TAIL_SERVER} "pkill -f -9 redis-server; sleep 1" || true

--- a/distributed_bench.sh
+++ b/distributed_bench.sh
@@ -19,10 +19,13 @@ for write_ratio in 1 ; do
     for num_nodes in  2; do
         echo 'num_clients throughput latency' > chain-${num_nodes}node-wr${write_ratio}.txt
 
-        for num_clients in 1; do
+        # for num_clients in 2; do
+            # for num_clients in 32; do
+                # for num_clients in $(seq 64 -4 1); do
+                for num_clients in 32; do
 
-            ssh -o StrictHostKeyChecking=no ubuntu@${HEAD_SERVER} "pkill -f -9 redis-server" || true
-            ssh -o StrictHostKeyChecking=no ubuntu@${TAIL_SERVER} "pkill -f -9 redis-server" || true
+            ssh -o StrictHostKeyChecking=no ubuntu@${HEAD_SERVER} "pkill -f -9 redis-server; sleep 1" || true
+            ssh -o StrictHostKeyChecking=no ubuntu@${TAIL_SERVER} "pkill -f -9 redis-server; sleep 1" || true
 
             # Launch master & head.
             ssh -o StrictHostKeyChecking=no ubuntu@${HEAD_SERVER} << EOF

--- a/distributed_bench.sh
+++ b/distributed_bench.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
+
+# distributed_bench.sh
 # Usage: run on client server.
+# TODO: this script assumes 2-node chain, one on each server.
 
 set -ex
 
@@ -18,21 +21,18 @@ for write_ratio in 1 ; do
 
         for num_clients in 1; do
 
+            ssh -o StrictHostKeyChecking=no ubuntu@${HEAD_SERVER} "pkill -f -9 redis-server" || true
+            ssh -o StrictHostKeyChecking=no ubuntu@${TAIL_SERVER} "pkill -f -9 redis-server" || true
+
             # Launch master & head.
             ssh -o StrictHostKeyChecking=no ubuntu@${HEAD_SERVER} << EOF
 cd ~/credis
-pkill -f -9 redis-server
-sleep 2
-./setup.sh $num_nodes
-sleep 2
+./setup.sh 1
 EOF
             # Launch tail.  We pass $HEAD_SERVER to setup.sh, which will skip master creation.
             ssh -o StrictHostKeyChecking=no ubuntu@${TAIL_SERVER} << EOF
 cd ~/credis
-pkill -f -9 redis-server
-sleep 2
-./setup.sh $num_nodes $HEAD_SERVER
-sleep 2
+./setup.sh 1 $HEAD_SERVER 6371
 EOF
 
             sleep 5

--- a/distributed_bench.sh
+++ b/distributed_bench.sh
@@ -14,8 +14,8 @@ N=${5:-""}
 
 pushd build; make -j; popd
 
-for write_ratio in 0.5 ; do
-    # for write_ratio in 1 ; do
+# for write_ratio in 0.5 ; do
+    for write_ratio in 1 ; do
     # Chain
     for num_nodes in  2; do
         echo 'num_clients throughput latency' > chain-${num_nodes}node-wr${write_ratio}.txt

--- a/distributed_bench.sh
+++ b/distributed_bench.sh
@@ -14,8 +14,8 @@ N=${5:-""}
 
 pushd build; make -j; popd
 
-# for write_ratio in 0.5 ; do
-    for write_ratio in 1 ; do
+for write_ratio in 0.5 ; do
+    # for write_ratio in 1 ; do
     # Chain
     for num_nodes in  2; do
         echo 'num_clients throughput latency' > chain-${num_nodes}node-wr${write_ratio}.txt
@@ -23,8 +23,10 @@ pushd build; make -j; popd
         for num_clients in 1; do
                 # for num_clients in 16; do
 
-            ssh -o StrictHostKeyChecking=no ubuntu@${HEAD_SERVER} "pkill -f -9 redis-server; sleep 1" || true
-            ssh -o StrictHostKeyChecking=no ubuntu@${TAIL_SERVER} "pkill -f -9 redis-server; sleep 1" || true
+            ssh -o StrictHostKeyChecking=no ubuntu@${HEAD_SERVER} "pkill redis-server; sleep 1; pkill redis-server;" || true
+            ssh -o StrictHostKeyChecking=no ubuntu@${TAIL_SERVER} "pkill redis-server; sleep 1; pkill redis-server;" || true
+
+            sleep 2
 
             # Launch master & head.
             ssh -o StrictHostKeyChecking=no ubuntu@${HEAD_SERVER} << EOF
@@ -37,7 +39,7 @@ cd ~/credis
 ./setup.sh 1 $HEAD_SERVER 6371
 EOF
 
-            sleep 5
+            # sleep 5
             ./distributed_seqput.sh $num_clients $num_nodes $write_ratio \
                                     $HEAD_SERVER $TAIL_SERVER $NODE_ADD $NODE_KILL $N &
             wait

--- a/distributed_seqput.sh
+++ b/distributed_seqput.sh
@@ -32,9 +32,11 @@ maybe_kill() {
     # Optionally, do node removal.
     if [ ! -z "${wait}" ]; then
         sleep ${wait}
-        echo 'Performing node removal...'
+        echo 'Performing node removal & instant spin-up...'
         ssh -o StrictHostKeyChecking=no ubuntu@${TAIL_SERVER} << EOF
-pkill -f redis-server.*:6371
+pkill -f -9 redis-server.*:6371
+cd ~/credis
+bash add.sh $HEAD_SERVER 6372
 EOF
     fi
 }
@@ -57,7 +59,7 @@ fi
 # maybe_add 2 &
 
 maybe_kill ${NODE_KILL} &
-maybe_add ${NODE_ADD} &
+# maybe_add ${NODE_ADD} &
 
 # NODE_KILL2=$((NODE_KILL * 3))
 # NODE_ADD2=$((NODE_ADD * 2))

--- a/distributed_seqput.sh
+++ b/distributed_seqput.sh
@@ -9,7 +9,7 @@ HEAD_SERVER=${4:-127.0.0.1}
 TAIL_SERVER=${5:-127.0.0.1}
 NODE_ADD=${6:-""}
 NODE_KILL=${7:-""}
-NUM_OPS=${8:-""}
+NUM_OPS=${8:-60000}
 
 eval NODE_ADD=$NODE_ADD
 eval NODE_KILL=$NODE_KILL
@@ -20,7 +20,7 @@ pkill -f credis_seqput_bench
 sleep 4
 
 for i in $(seq 1 $NUM_CLIENTS); do
-  logfile=${NUM_CLIENTS}clients-${i}-chain-${NUM_NODES}node-wr${WRITE_RATIO}.log
+  logfile=${NUM_CLIENTS}clients-${i}-chain_dist-${NUM_NODES}node-wr${WRITE_RATIO}.log
   ./build/src/credis_seqput_bench $NUM_NODES $WRITE_RATIO $HEAD_SERVER $NUM_OPS $TAIL_SERVER >${logfile} 2>&1 &
 done
 

--- a/distributed_seqput.sh
+++ b/distributed_seqput.sh
@@ -1,42 +1,27 @@
 #!/bin/bash
+# Usage: run on client server.
+
 set -x
 NUM_CLIENTS=${1:-1}
 NUM_NODES=${2:-1}
 WRITE_RATIO=${3:-1}
-SERVER=${4:-127.0.0.1}
-NODE_ADD=${5:-""}
-NODE_KILL=${6:-""}
-NUM_OPS=${7:-""}
+HEAD_SERVER=${4:-127.0.0.1}
+TAIL_SERVER=${5:-127.0.0.1}
+NODE_ADD=${6:-""}
+NODE_KILL=${7:-""}
+NUM_OPS=${8:-""}
 
 eval NODE_ADD=$NODE_ADD
 eval NODE_KILL=$NODE_KILL
 
-# Example usage:
-#
-#   # To launch.
-#   pkill -f redis-server; ./setup.sh 2; make -j;
-#   ./seqput.sh 12 2
-#
-#   # To calculate throughput.
-#   grep throughput client<1-12>.log | cut -d' ' -f 11 | sort -n | tail -n1 | awk '{time=$1/1000} END {print 500000*12/time}'
-
 pkill -f redis_seqput_bench
 pkill -f credis_seqput_bench
-
-ssh -o StrictHostKeyChecking=no ubuntu@${SERVER} << EOF
-cd ~/credis
-pkill -f -9 redis-server
-pkill -f -9 redis-server
-sleep 2
-./setup.sh $NUM_NODES
-sleep 2
-EOF
 
 sleep 4
 
 for i in $(seq 1 $NUM_CLIENTS); do
   logfile=${NUM_CLIENTS}clients-${i}-chain-${NUM_NODES}node-wr${WRITE_RATIO}.log
-  ./build/src/credis_seqput_bench $NUM_NODES $WRITE_RATIO $SERVER $NUM_OPS >${logfile} 2>&1 &
+  ./build/src/credis_seqput_bench $NUM_NODES $WRITE_RATIO $HEAD_SERVER $NUM_OPS $TAIL_SERVER >${logfile} 2>&1 &
 done
 
 maybe_add() {
@@ -44,9 +29,9 @@ maybe_add() {
 if [ ! -z "${NODE_ADD}" ]; then
     sleep ${NODE_ADD}
     echo 'Performing node addition...'
-    ssh -o StrictHostKeyChecking=no ubuntu@${SERVER} << EOF
+    ssh -o StrictHostKeyChecking=no ubuntu@${TAIL_SERVER} << EOF
 cd ~/credis
-bash add.sh
+bash add.sh $HEAD_SERVER
 EOF
 fi
 }
@@ -56,8 +41,8 @@ maybe_kill() {
     if [ ! -z "${NODE_KILL}" ]; then
         sleep ${NODE_KILL}
         echo 'Performing node removal...'
-        ssh -o StrictHostKeyChecking=no ubuntu@${SERVER} << EOF
-pkill -9 -f redis-server.*:6371
+        ssh -o StrictHostKeyChecking=no ubuntu@${TAIL_SERVER} << EOF
+pkill -9 -f redis-server.*:6370
 EOF
     fi
 }
@@ -67,7 +52,7 @@ maybe_kill &
 
 wait
 
-logs="${NUM_CLIENTS}clients-*-chain-${NUM_NODES}node-wr${WRITE_RATIO}.log"
+logs="${NUM_CLIENTS}clients-*-chain_dist-${NUM_NODES}node-wr${WRITE_RATIO}.log"
 outfile="chain-${NUM_NODES}node-wr${WRITE_RATIO}"
 
 # Composite

--- a/distributed_seqput.sh
+++ b/distributed_seqput.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# distributed_seqput.sh
 # Usage: run on client server.
 
 set -x
@@ -42,7 +43,7 @@ maybe_kill() {
         sleep ${NODE_KILL}
         echo 'Performing node removal...'
         ssh -o StrictHostKeyChecking=no ubuntu@${TAIL_SERVER} << EOF
-pkill -9 -f redis-server.*:6370
+pkill -9 -f redis-server.*:6371
 EOF
     fi
 }

--- a/distributed_seqput.sh
+++ b/distributed_seqput.sh
@@ -53,6 +53,9 @@ EOF
 fi
 }
 
+# maybe_kill 0 &
+# maybe_add 2 &
+
 maybe_kill ${NODE_KILL} &
 maybe_add ${NODE_ADD} &
 

--- a/distributed_seqput.sh
+++ b/distributed_seqput.sh
@@ -19,6 +19,8 @@ sleep 4
 
 agg_csv=${NUM_CLIENTS}clients-chain_dist-${NUM_NODES}node-wr${WRITE_RATIO}-$(date +%s).csv
 echo 'begin_timestamp_us,latency_us' > ${agg_csv}
+echo 'begin_timestamp_us,latency_us' > reads-${agg_csv}
+echo 'begin_timestamp_us,latency_us' > writes-${agg_csv}
 for i in $(seq 1 $NUM_CLIENTS); do
   logfile=${NUM_CLIENTS}clients-${i}-chain_dist-${NUM_NODES}node-wr${WRITE_RATIO}.log
   ./build/src/credis_seqput_bench $NUM_NODES $WRITE_RATIO $HEAD_SERVER $NUM_OPS $TAIL_SERVER ${agg_csv} >${logfile} 2>&1 &

--- a/seqput.sh
+++ b/seqput.sh
@@ -18,7 +18,7 @@ pkill -f redis_seqput_bench
 pkill -f credis_seqput_bench
 
 ssh -o StrictHostKeyChecking=no ubuntu@${SERVER} << EOF
-cd ~/credis-1
+cd ~/credis
 pkill -f redis-server
 sleep 2
 ./setup.sh $NUM_NODES
@@ -37,7 +37,8 @@ logs="${NUM_CLIENTS}clients-*-chain-${NUM_NODES}node-wr${WRITE_RATIO}.log"
 outfile="chain-${NUM_NODES}node-wr${WRITE_RATIO}"
 
 # Composite
-thput=$(grep throughput ${logs} | tr -s ' ' | cut -d' ' -f 11 | sort -n | tail -n1 | awk -v N=$NUM_CLIENTS '{time=$1/1000} END {print 50000*N/time}')
+num_ops=$(grep throughput ${logs} | tr -s ' ' | cut -d' ' -f 13 | tr -d ',' | sort -n | tail -n1)
+thput=$(grep throughput ${logs} | tr -s ' ' | cut -d' ' -f 11 | sort -n | tail -n1 | awk -v N=$NUM_CLIENTS -v O=$num_ops '{time=$1/1000} END {print O*N/time}')
 latency=$(grep latency ${logs} | tr -s ' ' | cut -d' ' -f 8 | awk  -v N=$NUM_CLIENTS '{s += $1} END {print s/N}')
 echo "$NUM_CLIENTS $thput $latency" >> ${outfile}.txt
 

--- a/seqput.sh
+++ b/seqput.sh
@@ -4,6 +4,7 @@ NUM_CLIENTS=${1:-1}
 NUM_NODES=${2:-1}
 WRITE_RATIO=${3:-1}
 SERVER=${4:-127.0.0.1}
+NODE_ADD=${5:-""}
 
 # Example usage:
 #
@@ -19,7 +20,7 @@ pkill -f credis_seqput_bench
 
 ssh -o StrictHostKeyChecking=no ubuntu@${SERVER} << EOF
 cd ~/credis
-pkill -f redis-server
+pkill -f -9 redis-server
 sleep 2
 ./setup.sh $NUM_NODES
 sleep 2
@@ -31,6 +32,17 @@ for i in $(seq 1 $NUM_CLIENTS); do
   logfile=${NUM_CLIENTS}clients-${i}-chain-${NUM_NODES}node-wr${WRITE_RATIO}.log
   ./build/src/credis_seqput_bench $NUM_NODES $WRITE_RATIO $SERVER >${logfile} 2>&1 &
 done
+
+# Optionally, do node addition.
+if [ ! -z "${NODE_ADD}" ]; then
+    sleep ${NODE_ADD}
+    echo 'Performing node addition...'
+    ssh -o StrictHostKeyChecking=no ubuntu@${SERVER} << EOF
+cd ~/credis
+bash add.sh
+EOF
+fi
+
 wait
 
 logs="${NUM_CLIENTS}clients-*-chain-${NUM_NODES}node-wr${WRITE_RATIO}.log"

--- a/setup.sh
+++ b/setup.sh
@@ -26,7 +26,8 @@ function setup() {
 
     sleep 2
 
-    myip=$(curl ipinfo.io/ip 2>/dev/null)
+    # myip=$(curl ipinfo.io/ip 2>/dev/null)
+    myip=$(hostname -i)
     for i in $(seq 1 $NUM_NODES); do
       taskset 0x1 \
               ./redis/src/redis-server --loadmodule ./build/src/libmember.so ${gcs_mode} --port $port --protected-mode no &> $port.log &

--- a/setup.sh
+++ b/setup.sh
@@ -4,6 +4,8 @@ set -ex
 # Defaults to 1, or 1st arg if provided.
 # Master is assigned port 6369.  Chain node i gets port 6369+i.
 NUM_NODES=${1:-1}
+# If present, use 6369 on this server as the master.
+HEAD_SERVER=${2:-""}
 
 gcs_normal=0
 gcs_ckptonly=1
@@ -16,26 +18,23 @@ function setup() {
     make -j
     popd
 
-    # Master.
-    ./redis/src/redis-server --loadmodule ./build/src/libmaster.so --port 6369 --protected-mode no &> master.log &
+    if [ -z "${HEAD_SERVER}" ]; then
+      # Master.
+      ./redis/src/redis-server --loadmodule ./build/src/libmaster.so --port 6369 --protected-mode no &> master.log &
+      HEAD_SERVER="127.0.0.1"
+    fi
+
+    myip=$(curl ipinfo.io/ip)
 
     port=6369
     for i in $(seq 1 $NUM_NODES); do
       port=$(expr $port + 1)
-      #LD_PRELOAD=/usr/lib/libprofiler.so CPUPROFILE=/tmp/pprof-${i} \
-      #  ./redis/src/redis-server --loadmodule ./build/src/libmember.so \
-      #  --protected-mode no --port $port &> $port.log &
-
-      # sudo cgexec -g memory:redisgroup ./redis/src/redis-server --loadmodule ./build/src/libmember.so ${gcs_mode} --port $port --protected-mode no &> $port.log &
-      ./redis/src/redis-server --loadmodule ./build/src/libmember.so ${gcs_mode} --port $port --protected-mode no &> $port.log &
+      taskset 0x1 \
+              ./redis/src/redis-server --loadmodule ./build/src/libmember.so ${gcs_mode} --port $port --protected-mode no &> $port.log &
 
       sleep 0.5
-      myip=$(curl ipinfo.io/ip)
-      ./redis/src/redis-cli -p 6369 MASTER.ADD ${myip} $port
+      ./redis/src/redis-cli -h ${HEAD_SERVER} -p 6369 MASTER.ADD ${myip} $port
 
-      # Have chain nodes connect to master.
-      sleep 0.5
-      ./redis/src/redis-cli -p $port MEMBER.CONNECT_TO_MASTER 127.0.0.1 6369
     done
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -17,7 +17,7 @@ function setup() {
     popd
 
     # Master.
-    ./redis/src/redis-server --loadmodule ./build/src/libmaster.so --port 6369 &> master.log &
+    ./redis/src/redis-server --loadmodule ./build/src/libmaster.so --port 6369 --protected-mode no &> master.log &
 
     port=6369
     for i in $(seq 1 $NUM_NODES); do
@@ -30,7 +30,8 @@ function setup() {
       ./redis/src/redis-server --loadmodule ./build/src/libmember.so ${gcs_mode} --port $port --protected-mode no &> $port.log &
 
       sleep 0.5
-      ./redis/src/redis-cli -p 6369 MASTER.ADD 127.0.0.1 $port
+      myip=$(curl ipinfo.io/ip)
+      ./redis/src/redis-cli -p 6369 MASTER.ADD ${myip} $port
 
       # Have chain nodes connect to master.
       sleep 0.5

--- a/setup.sh
+++ b/setup.sh
@@ -26,6 +26,7 @@ function setup() {
 
     myip=$(curl ipinfo.io/ip)
 
+    myip=$(curl ipinfo.io/ip)
     port=6369
     for i in $(seq 1 $NUM_NODES); do
       port=$(expr $port + 1)
@@ -35,7 +36,12 @@ function setup() {
       sleep 0.5
       ./redis/src/redis-cli -h ${HEAD_SERVER} -p 6369 MASTER.ADD ${myip} $port
 
+
+# Have chain nodes connect to master.
+#    sleep 0.5
+#    ./redis/src/redis-cli -p $port MEMBER.CONNECT_TO_MASTER 127.0.0.1 6369
     done
+    # ./redis/src/redis-cli -p 6370 MONITOR &>monitor-6370.log &
 }
 
 setup

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,7 +17,6 @@ else()
   set(MALLOC_LIBRARY "${CMAKE_SOURCE_DIR}/redis/deps/jemalloc/lib/libjemalloc.a")
 endif()
 
-# set(REDIS_MODULE_CFLAGS -W -Wall -fno-common -g -ggdb -std=c++11)
 set(REDIS_MODULE_CFLAGS -W -Wall -fno-common -g -ggdb -std=c++11 -O2)
 if(APPLE)
   set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
@@ -34,14 +33,12 @@ target_link_libraries(timer glog::glog)
 # utils
 add_library(utils STATIC utils.cc)
 target_compile_options(utils PUBLIC ${REDIS_MODULE_CFLAGS} -fPIC)
-# target_link_libraries(utils ${REDIS_MODULE_LDFLAGS})
 
 # master_client
 add_library(master_client STATIC master_client.cc)
 target_compile_options(master_client PUBLIC ${REDIS_MODULE_CFLAGS} -fPIC)
 target_link_libraries(master_client ${LevelDB_LIBRARIES})
 target_link_libraries(master_client glog::glog)
-# target_link_libraries(master_client utils)
 
 # client
 add_library(client STATIC client.cc)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ else()
   set(MALLOC_LIBRARY "${CMAKE_SOURCE_DIR}/redis/deps/jemalloc/lib/libjemalloc.a")
 endif()
 
+# set(REDIS_MODULE_CFLAGS -W -Wall -fno-common -g -ggdb -std=c++11)
 set(REDIS_MODULE_CFLAGS -W -Wall -fno-common -g -ggdb -std=c++11 -O2)
 if(APPLE)
   set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
@@ -33,12 +34,14 @@ target_link_libraries(timer glog::glog)
 # utils
 add_library(utils STATIC utils.cc)
 target_compile_options(utils PUBLIC ${REDIS_MODULE_CFLAGS} -fPIC)
+# target_link_libraries(utils ${REDIS_MODULE_LDFLAGS})
 
 # master_client
 add_library(master_client STATIC master_client.cc)
 target_compile_options(master_client PUBLIC ${REDIS_MODULE_CFLAGS} -fPIC)
 target_link_libraries(master_client ${LevelDB_LIBRARIES})
 target_link_libraries(master_client glog::glog)
+# target_link_libraries(master_client utils)
 
 # client
 add_library(client STATIC client.cc)
@@ -78,7 +81,7 @@ target_link_libraries(credis_seqput_bench glog::glog client
   ${CMAKE_SOURCE_DIR}/redis/deps/hiredis/libhiredis.a
   ${CMAKE_SOURCE_DIR}/redis/src/ae.o
   ${CMAKE_SOURCE_DIR}/redis/src/zmalloc.o
-  ${MALLOC_LIBRARY} timer)
+  ${MALLOC_LIBRARY} timer master_client)
 
 add_executable(redis_parput_bench redis_parput_bench.cc)
 target_link_libraries(redis_parput_bench glog::glog client

--- a/src/chain_module.h
+++ b/src/chain_module.h
@@ -41,56 +41,59 @@ void RedisDisconnectCallback(const redisAsyncContext* c, int status) {
   LOG(INFO) << "Error: " << c->errstr;
   LOG(INFO) << "Remote host " << c->c.tcp.host;
 
-  // TODO(zongheng): should we clean up event loop?  should we call
-  // asyncDisconnect()?
-  if (!c->err) {
-    LOG(INFO) << "!c->err";
-    redisAsyncDisconnect(const_cast<redisAsyncContext*>(c));
-  } else {
-    // This causes accessing 0x0, segfault.
-    // Backtrace:
-    // ./redis/src/redis-server *:6370(logStackTrace+0x45)[0x46ae75]
-    // ./redis/src/redis-server *:6370(sigsegvHandler+0xb9)[0x46b639]
-    // /lib/x86_64-linux-gnu/libpthread.so.0(+0x11390)[0x7f56dbbb1390]
-    // /lib/x86_64-linux-gnu/libc.so.6(cfree+0x42)[0x7f56db85a532]
-    // ./redis/src/redis-server *:6370[0x49e113]
-    // ./redis/src/redis-server *:6370[0x49e81b]
-    // ./build/src/libmember.so(+0x18069)[0x7f56d97c4069]
-    // ./redis/src/redis-server *:6370[0x49e86b]
-    // ./redis/src/redis-server *:6370(aeProcessEvents+0x13e)[0x42592e]
-    // ./redis/src/redis-server *:6370(aeMain+0x2b)[0x425d5b]
-    // ./redis/src/redis-server *:6370(main+0x4a6)[0x422926]
-    // /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0)[0x7f56db7f6830]
-    // ./redis/src/redis-server *:6370(_start+0x29)[0x422c29]
-    // LOG(INFO) << "c->err, trying redisAsyncDisconnect anyway";
+  // // TODO(zongheng): should we clean up event loop?  should we call
+  // // asyncDisconnect()?
+  // if (!c->err) {
+  //   LOG(INFO) << "!c->err";
+  //   redisAsyncDisconnect(const_cast<redisAsyncContext*>(c));
+  // } else {
+  //   // This causes accessing 0x0, segfault.
+  //   // Backtrace:
+  //   // ./redis/src/redis-server *:6370(logStackTrace+0x45)[0x46ae75]
+  //   // ./redis/src/redis-server *:6370(sigsegvHandler+0xb9)[0x46b639]
+  //   // /lib/x86_64-linux-gnu/libpthread.so.0(+0x11390)[0x7f56dbbb1390]
+  //   // /lib/x86_64-linux-gnu/libc.so.6(cfree+0x42)[0x7f56db85a532]
+  //   // ./redis/src/redis-server *:6370[0x49e113]
+  //   // ./redis/src/redis-server *:6370[0x49e81b]
+  //   // ./build/src/libmember.so(+0x18069)[0x7f56d97c4069]
+  //   // ./redis/src/redis-server *:6370[0x49e86b]
+  //   // ./redis/src/redis-server *:6370(aeProcessEvents+0x13e)[0x42592e]
+  //   // ./redis/src/redis-server *:6370(aeMain+0x2b)[0x425d5b]
+  //   // ./redis/src/redis-server *:6370(main+0x4a6)[0x422926]
+  //   //
+  //   /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0)[0x7f56db7f6830]
+  //   // ./redis/src/redis-server *:6370(_start+0x29)[0x422c29]
+  //   // LOG(INFO) << "c->err, trying redisAsyncDisconnect anyway";
 
-    // 22 I0426 19:31:25.395185 59211 chain_module.h:67] (c->ev.data ==
-    // nullptr)? 0
-    //                                                     23 *** Error in
-    //                                                     `./redis/src/redis-server
-    //                                                     *:6370': double free
-    //                                                     or corruption
-    //                                                     (fasttop):
-    //                                                     0x0000000001347dd0
-    //                                                     ***
-    // 24 ======= Backtrace: =========
-    // 25 /lib/x86_64-linux-gnu/libc.so.6(+0x777e5)[0x7f79f94957e5]
-    // 26 /lib/x86_64-linux-gnu/libc.so.6(+0x8037a)[0x7f79f949e37a]
-    // 27 /lib/x86_64-linux-gnu/libc.so.6(cfree+0x4c)[0x7f79f94a253c]
-    // 28 ./build/src/libmember.so(+0x18128)[0x7f79f75c4128]
-    // 29 ./redis/src/redis-server *:6370[0x49e86b]
-    // 30 ./redis/src/redis-server *:6370(aeProcessEvents+0x13e)[0x42592e]
-    // 31 ./redis/src/redis-server *:6370(aeMain+0x2b)[0x425d5b]
-    // 32 ./redis/src/redis-server *:6370(main+0x4a6)[0x422926]
-    // 33
-    // /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0)[0x7f79f943e830]
-    // 34 ./redis/src/redis-server *:6370(_start+0x29)[0x422c29]
-    // bool isnull = (c->ev.data == nullptr);
-    // LOG(INFO) << "(c->ev.data == nullptr)? " << isnull;
-    // c->ev.cleanup(c->ev.data);
-    // redisAsyncDisconnect(const_cast<redisAsyncContext*>(c));
-  }
-  // c->ev.cleanup(c->ev.data);
+  //   // 22 I0426 19:31:25.395185 59211 chain_module.h:67] (c->ev.data ==
+  //   // nullptr)? 0
+  //   //                                                     23 *** Error in
+  //   // `./redis/src/redis-server
+  //   //                                                     *:6370': double
+  //   free
+  //   //                                                     or corruption
+  //   //                                                     (fasttop):
+  //   //                                                     0x0000000001347dd0
+  //   //                                                     ***
+  //   // 24 ======= Backtrace: =========
+  //   // 25 /lib/x86_64-linux-gnu/libc.so.6(+0x777e5)[0x7f79f94957e5]
+  //   // 26 /lib/x86_64-linux-gnu/libc.so.6(+0x8037a)[0x7f79f949e37a]
+  //   // 27 /lib/x86_64-linux-gnu/libc.so.6(cfree+0x4c)[0x7f79f94a253c]
+  //   // 28 ./build/src/libmember.so(+0x18128)[0x7f79f75c4128]
+  //   // 29 ./redis/src/redis-server *:6370[0x49e86b]
+  //   // 30 ./redis/src/redis-server *:6370(aeProcessEvents+0x13e)[0x42592e]
+  //   // 31 ./redis/src/redis-server *:6370(aeMain+0x2b)[0x425d5b]
+  //   // 32 ./redis/src/redis-server *:6370(main+0x4a6)[0x422926]
+  //   // 33
+  //   //
+  //   /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0)[0x7f79f943e830]
+  //   // 34 ./redis/src/redis-server *:6370(_start+0x29)[0x422c29]
+  //   // bool isnull = (c->ev.data == nullptr);
+  //   // LOG(INFO) << "(c->ev.data == nullptr)? " << isnull;
+  //   // c->ev.cleanup(c->ev.data);
+  //   // redisAsyncDisconnect(const_cast<redisAsyncContext*>(c));
+  // }
+  // // c->ev.cleanup(c->ev.data);
 
   // The context object is always freed after the disconnect callback fired.
   // When a reconnect is needed, the disconnect callback is a good point to do
@@ -223,29 +226,42 @@ class RedisChainModule {
     if (parent_) redisAsyncFree(parent_);
   }
 
-  void Reset(std::string& prev_address, std::string& prev_port,
-             std::string& next_address, std::string& next_port) {
-    prev_address_ = prev_address;
-    prev_port_ = prev_port;
-    next_address_ = next_address;
-    next_port_ = next_port;
-
+  void Reset(const std::string& prev_address, const std::string& prev_port,
+             const std::string& next_address, const std::string& next_port) {
     // If "c->err" is present, the disconnect callback should've already free'd
     // the async context.
-    if (child_ && !child_->err) {
-      redisAsyncDisconnect(child_);
-    }
-    if (parent_ && !parent_->err) {
-      redisAsyncDisconnect(parent_);
+    if (!next_address.empty()) {
+      next_address_ = next_address;
+      next_port_ = next_port;
+
+      if (child_ && !child_->err) {
+        redisAsyncDisconnect(child_);
+      }
+      child_ = nullptr;
+      if (next_address != "nil") {
+        child_ = AsyncConnect(next_address, std::stoi(next_port));
+
+        // // TODO(zongheng): remove these!!
+        // redisAsyncDisconnect(child_);
+        // child_ = AsyncConnect(next_address, std::stoi(next_port));
+      }
     }
 
-    child_ = NULL;
-    parent_ = NULL;
-    if (next_address != "nil") {
-      child_ = AsyncConnect(next_address, std::stoi(next_port));
-    }
-    if (prev_address != "nil") {
-      parent_ = AsyncConnect(prev_address, std::stoi(prev_port));
+    if (!prev_address.empty()) {
+      prev_address_ = prev_address;
+      prev_port_ = prev_port;
+
+      if (parent_ && !parent_->err) {
+        redisAsyncDisconnect(parent_);
+      }
+      parent_ = nullptr;
+      if (prev_address != "nil") {
+        parent_ = AsyncConnect(prev_address, std::stoi(prev_port));
+
+        // // TODO(zongheng): remove these!!
+        // redisAsyncDisconnect(parent_);
+        // parent_ = AsyncConnect(prev_address, std::stoi(prev_port));
+      }
     }
   }
 

--- a/src/chain_module.h
+++ b/src/chain_module.h
@@ -43,7 +43,53 @@ void RedisDisconnectCallback(const redisAsyncContext* c, int status) {
 
   // TODO(zongheng): should we clean up event loop?  should we call
   // asyncDisconnect()?
-  // redisAsyncDisconnect(c);
+  if (!c->err) {
+    LOG(INFO) << "!c->err";
+    redisAsyncDisconnect(const_cast<redisAsyncContext*>(c));
+  } else {
+    // This causes accessing 0x0, segfault.
+    // Backtrace:
+    // ./redis/src/redis-server *:6370(logStackTrace+0x45)[0x46ae75]
+    // ./redis/src/redis-server *:6370(sigsegvHandler+0xb9)[0x46b639]
+    // /lib/x86_64-linux-gnu/libpthread.so.0(+0x11390)[0x7f56dbbb1390]
+    // /lib/x86_64-linux-gnu/libc.so.6(cfree+0x42)[0x7f56db85a532]
+    // ./redis/src/redis-server *:6370[0x49e113]
+    // ./redis/src/redis-server *:6370[0x49e81b]
+    // ./build/src/libmember.so(+0x18069)[0x7f56d97c4069]
+    // ./redis/src/redis-server *:6370[0x49e86b]
+    // ./redis/src/redis-server *:6370(aeProcessEvents+0x13e)[0x42592e]
+    // ./redis/src/redis-server *:6370(aeMain+0x2b)[0x425d5b]
+    // ./redis/src/redis-server *:6370(main+0x4a6)[0x422926]
+    // /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0)[0x7f56db7f6830]
+    // ./redis/src/redis-server *:6370(_start+0x29)[0x422c29]
+    // LOG(INFO) << "c->err, trying redisAsyncDisconnect anyway";
+
+    // 22 I0426 19:31:25.395185 59211 chain_module.h:67] (c->ev.data ==
+    // nullptr)? 0
+    //                                                     23 *** Error in
+    //                                                     `./redis/src/redis-server
+    //                                                     *:6370': double free
+    //                                                     or corruption
+    //                                                     (fasttop):
+    //                                                     0x0000000001347dd0
+    //                                                     ***
+    // 24 ======= Backtrace: =========
+    // 25 /lib/x86_64-linux-gnu/libc.so.6(+0x777e5)[0x7f79f94957e5]
+    // 26 /lib/x86_64-linux-gnu/libc.so.6(+0x8037a)[0x7f79f949e37a]
+    // 27 /lib/x86_64-linux-gnu/libc.so.6(cfree+0x4c)[0x7f79f94a253c]
+    // 28 ./build/src/libmember.so(+0x18128)[0x7f79f75c4128]
+    // 29 ./redis/src/redis-server *:6370[0x49e86b]
+    // 30 ./redis/src/redis-server *:6370(aeProcessEvents+0x13e)[0x42592e]
+    // 31 ./redis/src/redis-server *:6370(aeMain+0x2b)[0x425d5b]
+    // 32 ./redis/src/redis-server *:6370(main+0x4a6)[0x422926]
+    // 33
+    // /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0)[0x7f79f943e830]
+    // 34 ./redis/src/redis-server *:6370(_start+0x29)[0x422c29]
+    // bool isnull = (c->ev.data == nullptr);
+    // LOG(INFO) << "(c->ev.data == nullptr)? " << isnull;
+    // c->ev.cleanup(c->ev.data);
+    // redisAsyncDisconnect(const_cast<redisAsyncContext*>(c));
+  }
   // c->ev.cleanup(c->ev.data);
 
   // The context object is always freed after the disconnect callback fired.

--- a/src/chain_module.h
+++ b/src/chain_module.h
@@ -99,14 +99,14 @@ class RedisChainModule {
   }
   std::string gcs_mode_string() const {
     switch (gcs_mode_) {
-    case GcsMode::kNormal:
-      return "kNormal";
-    case GcsMode::kCkptOnly:
-      return "kCkptOnly";
-    case GcsMode::kCkptFlush:
-      return "kCkptFlush";
-    default:
-      CHECK(false);
+      case GcsMode::kNormal:
+        return "kNormal";
+      case GcsMode::kCkptOnly:
+        return "kCkptOnly";
+      case GcsMode::kCkptFlush:
+        return "kCkptFlush";
+      default:
+        CHECK(false);
     }
   }
 
@@ -122,12 +122,12 @@ class RedisChainModule {
   }
   std::string master_mode_string() const {
     switch (master_mode_) {
-    case MasterMode::kRedis:
-      return "kRedis";
-    case MasterMode::kEtcd:
-      return "kEtcd";
-    default:
-      CHECK(false);
+      case MasterMode::kRedis:
+        return "kRedis";
+      case MasterMode::kEtcd:
+        return "kEtcd";
+      default:
+        CHECK(false);
     }
   }
 
@@ -138,13 +138,13 @@ class RedisChainModule {
         parent_(NULL),
         child_(NULL) {
     switch (master_mode_) {
-    case MasterMode::kRedis:
-      master_client_ = std::unique_ptr<MasterClient>(new RedisMasterClient());
-      break;
-    case MasterMode::kEtcd:
-      CHECK(false) << "Etcd master client is unimplemented";
-    default:
-      CHECK(false) << "Unrecognized master mode " << master_mode_string();
+      case MasterMode::kRedis:
+        master_client_ = std::unique_ptr<MasterClient>(new RedisMasterClient());
+        break;
+      case MasterMode::kEtcd:
+        CHECK(false) << "Etcd master client is unimplemented";
+      default:
+        CHECK(false) << "Unrecognized master mode " << master_mode_string();
     }
   }
 
@@ -153,10 +153,8 @@ class RedisChainModule {
     if (parent_) redisAsyncFree(parent_);
   }
 
-  void Reset(std::string& prev_address,
-             std::string& prev_port,
-             std::string& next_address,
-             std::string& next_port) {
+  void Reset(std::string& prev_address, std::string& prev_port,
+             std::string& next_address, std::string& next_port) {
     prev_address_ = prev_address;
     prev_port_ = prev_port;
     next_address_ = next_address;
@@ -242,18 +240,15 @@ class RedisChainModule {
       std::function<int(RedisModuleCtx*, RedisModuleString**, int)>;
   // Runs "node_func" on every node in the chain; after the tail node has run it
   // too, finalizes the mutation by running "tail_func".
-  using NodeFunc = std::function<int(
-      RedisModuleCtx*, RedisModuleString**, int, RedisModuleString**)>;
+  using NodeFunc = std::function<int(RedisModuleCtx*, RedisModuleString**, int,
+                                     RedisModuleString**)>;
   using TailFunc =
       std::function<int(RedisModuleCtx*, RedisModuleString**, int)>;
 
   // Runs "node_func" on every node in the chain; after the tail node has run it
   // too, finalizes the mutation by running "tail_func".
-  int ChainReplicate(RedisModuleCtx* ctx,
-                     RedisModuleString** argv,
-                     int argc,
-                     NodeFunc node_func,
-                     TailFunc tail_func);
+  int ChainReplicate(RedisModuleCtx* ctx, RedisModuleString** argv, int argc,
+                     NodeFunc node_func, TailFunc tail_func);
 
  private:
   std::string prev_address_;
@@ -302,19 +297,13 @@ class RedisChainModule {
   // Drop writes.  Used when adding a child which acts as the new tail.
   bool drop_writes_ = false;
 
-  int MutateHelper(RedisModuleCtx* ctx,
-                   RedisModuleString** argv,
-                   int argc,
-                   NodeFunc node_func,
-                   TailFunc tail_func,
-                   int sn);
+  int MutateHelper(RedisModuleCtx* ctx, RedisModuleString** argv, int argc,
+                   NodeFunc node_func, TailFunc tail_func, int sn);
 };
 
 int RedisChainModule::MutateHelper(RedisModuleCtx* ctx,
-                                   RedisModuleString** argv,
-                                   int argc,
-                                   NodeFunc node_func,
-                                   TailFunc tail_func,
+                                   RedisModuleString** argv, int argc,
+                                   NodeFunc node_func, TailFunc tail_func,
                                    int sn) {
   // Node function.  Retrieve the mutated key.
   RedisModuleString* redis_key_str = nullptr;
@@ -341,10 +330,8 @@ int RedisChainModule::MutateHelper(RedisModuleCtx* ctx,
 }
 
 int RedisChainModule::ChainReplicate(RedisModuleCtx* ctx,
-                                     RedisModuleString** argv,
-                                     int argc,
-                                     NodeFunc node_func,
-                                     TailFunc tail_func) {
+                                     RedisModuleString** argv, int argc,
+                                     NodeFunc node_func, TailFunc tail_func) {
   CHECK(Role() == RedisChainModule::ChainRole::kSingleton)
       << "ChainReplicate() API supports 1-node mode only for now due to "
          "insufficient "

--- a/src/chain_module.h
+++ b/src/chain_module.h
@@ -40,61 +40,6 @@ void RedisDisconnectCallback(const redisAsyncContext* c, int status) {
             << c->c.tcp.port;
   LOG(INFO) << "Error: " << c->errstr;
   LOG(INFO) << "Remote host " << c->c.tcp.host;
-
-  // // TODO(zongheng): should we clean up event loop?  should we call
-  // // asyncDisconnect()?
-  // if (!c->err) {
-  //   LOG(INFO) << "!c->err";
-  //   redisAsyncDisconnect(const_cast<redisAsyncContext*>(c));
-  // } else {
-  //   // This causes accessing 0x0, segfault.
-  //   // Backtrace:
-  //   // ./redis/src/redis-server *:6370(logStackTrace+0x45)[0x46ae75]
-  //   // ./redis/src/redis-server *:6370(sigsegvHandler+0xb9)[0x46b639]
-  //   // /lib/x86_64-linux-gnu/libpthread.so.0(+0x11390)[0x7f56dbbb1390]
-  //   // /lib/x86_64-linux-gnu/libc.so.6(cfree+0x42)[0x7f56db85a532]
-  //   // ./redis/src/redis-server *:6370[0x49e113]
-  //   // ./redis/src/redis-server *:6370[0x49e81b]
-  //   // ./build/src/libmember.so(+0x18069)[0x7f56d97c4069]
-  //   // ./redis/src/redis-server *:6370[0x49e86b]
-  //   // ./redis/src/redis-server *:6370(aeProcessEvents+0x13e)[0x42592e]
-  //   // ./redis/src/redis-server *:6370(aeMain+0x2b)[0x425d5b]
-  //   // ./redis/src/redis-server *:6370(main+0x4a6)[0x422926]
-  //   //
-  //   /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0)[0x7f56db7f6830]
-  //   // ./redis/src/redis-server *:6370(_start+0x29)[0x422c29]
-  //   // LOG(INFO) << "c->err, trying redisAsyncDisconnect anyway";
-
-  //   // 22 I0426 19:31:25.395185 59211 chain_module.h:67] (c->ev.data ==
-  //   // nullptr)? 0
-  //   //                                                     23 *** Error in
-  //   // `./redis/src/redis-server
-  //   //                                                     *:6370': double
-  //   free
-  //   //                                                     or corruption
-  //   //                                                     (fasttop):
-  //   //                                                     0x0000000001347dd0
-  //   //                                                     ***
-  //   // 24 ======= Backtrace: =========
-  //   // 25 /lib/x86_64-linux-gnu/libc.so.6(+0x777e5)[0x7f79f94957e5]
-  //   // 26 /lib/x86_64-linux-gnu/libc.so.6(+0x8037a)[0x7f79f949e37a]
-  //   // 27 /lib/x86_64-linux-gnu/libc.so.6(cfree+0x4c)[0x7f79f94a253c]
-  //   // 28 ./build/src/libmember.so(+0x18128)[0x7f79f75c4128]
-  //   // 29 ./redis/src/redis-server *:6370[0x49e86b]
-  //   // 30 ./redis/src/redis-server *:6370(aeProcessEvents+0x13e)[0x42592e]
-  //   // 31 ./redis/src/redis-server *:6370(aeMain+0x2b)[0x425d5b]
-  //   // 32 ./redis/src/redis-server *:6370(main+0x4a6)[0x422926]
-  //   // 33
-  //   //
-  //   /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0)[0x7f79f943e830]
-  //   // 34 ./redis/src/redis-server *:6370(_start+0x29)[0x422c29]
-  //   // bool isnull = (c->ev.data == nullptr);
-  //   // LOG(INFO) << "(c->ev.data == nullptr)? " << isnull;
-  //   // c->ev.cleanup(c->ev.data);
-  //   // redisAsyncDisconnect(const_cast<redisAsyncContext*>(c));
-  // }
-  // // c->ev.cleanup(c->ev.data);
-
   // The context object is always freed after the disconnect callback fired.
   // When a reconnect is needed, the disconnect callback is a good point to do
   // so.
@@ -111,7 +56,6 @@ redisAsyncContext* AsyncConnect(const std::string& address, int port) {
     }
     return NULL;
   }
-  // redisAsyncSetDisconnectCallback(c, &DisconnectCallback);
   CHECK(redisAsyncSetDisconnectCallback(c, &RedisDisconnectCallback) ==
         REDIS_OK);
   return c;
@@ -228,22 +172,18 @@ class RedisChainModule {
 
   void Reset(const std::string& prev_address, const std::string& prev_port,
              const std::string& next_address, const std::string& next_port) {
-    // If "c->err" is present, the disconnect callback should've already free'd
-    // the async context.
     if (!next_address.empty()) {
       next_address_ = next_address;
       next_port_ = next_port;
 
+      // If "c->err" is present, the disconnect callback should've already
+      // free'd the async context.
       if (child_ && !child_->err) {
         redisAsyncDisconnect(child_);
       }
       child_ = nullptr;
       if (next_address != "nil") {
         child_ = AsyncConnect(next_address, std::stoi(next_port));
-
-        // // TODO(zongheng): remove these!!
-        // redisAsyncDisconnect(child_);
-        // child_ = AsyncConnect(next_address, std::stoi(next_port));
       }
     }
 
@@ -257,10 +197,6 @@ class RedisChainModule {
       parent_ = nullptr;
       if (prev_address != "nil") {
         parent_ = AsyncConnect(prev_address, std::stoi(prev_port));
-
-        // // TODO(zongheng): remove these!!
-        // redisAsyncDisconnect(parent_);
-        // parent_ = AsyncConnect(prev_address, std::stoi(prev_port));
       }
     }
   }

--- a/src/client.cc
+++ b/src/client.cc
@@ -1,14 +1,17 @@
 #include "client.h"
 
+#include <cstring>
+#include <iostream>
+
 // This is a global redis callback which will be registered for every
 // asynchronous redis call. It dispatches the appropriate callback
 // that was registered with the RedisCallbackManager.
-void GlobalRedisCallback(void* c, void* r, void* privdata) {
+void GlobalRedisCallback(void *c, void *r, void *privdata) {
   if (r == NULL) {
     return;
   }
   int64_t callback_index = reinterpret_cast<int64_t>(privdata);
-  redisReply* reply = reinterpret_cast<redisReply*>(r);
+  redisReply *reply = reinterpret_cast<redisReply *>(r);
   std::string data = "";
   if (reply->type == REDIS_REPLY_NIL) {
   } else if (reply->type == REDIS_REPLY_STRING) {
@@ -25,48 +28,99 @@ void GlobalRedisCallback(void* c, void* r, void* privdata) {
   RedisCallbackManager::instance().get(callback_index)(data);
 }
 
-int64_t RedisCallbackManager::add(const RedisCallback& function) {
+int64_t RedisCallbackManager::add(const RedisCallback &function) {
   callbacks_.emplace(num_callbacks, std::unique_ptr<RedisCallback>(
                                         new RedisCallback(function)));
   return num_callbacks++;
 }
 
-RedisCallbackManager::RedisCallback& RedisCallbackManager::get(
-    int64_t callback_index) {
+RedisCallbackManager::RedisCallback &
+RedisCallbackManager::get(int64_t callback_index) {
   return *callbacks_[callback_index];
 }
 
-#define REDIS_CHECK_ERROR(CONTEXT, REPLY)                     \
-  if (REPLY == nullptr || REPLY->type == REDIS_REPLY_ERROR) { \
-    return Status::IOError(CONTEXT->errstr);                  \
+#define REDIS_CHECK_ERROR(CONTEXT, REPLY)                                      \
+  if (REPLY == nullptr || REPLY->type == REDIS_REPLY_ERROR) {                  \
+    return Status::IOError(CONTEXT->errstr);                                   \
   }
 
 RedisClient::~RedisClient() {
-  if (context_) redisFree(context_);
-  if (write_context_) redisAsyncFree(write_context_);
-  if (read_context_) redisAsyncFree(read_context_);
+  if (context_)
+    redisFree(context_);
+  if (write_context_)
+    redisAsyncFree(write_context_);
+  if (read_context_)
+    redisAsyncFree(read_context_);
 }
 
 constexpr int64_t kRedisDBConnectRetries = 50;
 constexpr int64_t kRedisDBWaitMilliseconds = 100;
 
 namespace {
-Status ConnectContext(const std::string& address,
-                      int port,
-                      redisAsyncContext** context) {
-  redisAsyncContext* ctx = redisAsyncConnect(address.c_str(), port);
+// The asynchronous context can hold a disconnect callback function that is
+// called when the connection is disconnected (either because of an error or per
+// user request). This function should have the following prototype:
+
+//    void(const redisAsyncContext *c, int status);
+// On a disconnect, the status argument is set to REDIS_OK when disconnection
+// was initiated by the user, or REDIS_ERR when the disconnection was caused by
+// an error. When it is REDIS_ERR, the err field in the context can be accessed
+// to find out the cause of the error.
+
+//   The context object is always freed after the disconnect callback fired.
+//   When a reconnect is needed, the disconnect callback is a good point to do
+//   so.
+
+//  Setting the disconnect callback can only be done once per context. For
+//  subsequent calls it will return REDIS_ERR. The function to set the
+//  disconnect callback has the following prototype:
+
+// int redisAsyncSetDisconnectCallback(redisAsyncContext *ac,
+// redisDisconnectCallback *fn);
+
+void RedisDisconnectCallback(const redisAsyncContext *c, int status) {
+  // NOTE(zongheng): for some reason LOG(INFO) from glog cannot be used at
+  // client program exit.  This callback seems to fire after glog finishes its
+  // own teardown, resulting in segfault.
+
+  // LOG(INFO) << "status == REDIS_ERR? " << (status == REDIS_ERR);
+  std::cout << "Disconnected redisAsyncContext to remote port " << c->c.tcp.port
+            << std::endl;
+  // LOG(INFO) << "Disconnected redisAsyncContext";
+  // if (status == REDIS_ERR) {
+  //   std::cout << "Error: " << std::string(c->errstr) << std::endl;
+  // }
+  // std::cout << std::strlen(c->c.tcp.host) << " "
+  //           << std::strlen(c->c.tcp.source_addr) << std::endl;
+  // if (std::strlen(c->c.tcp.host)) {
+  //   std::cout << "host " << std::string(c->c.tcp.host) << std::endl;
+  // }
+  // if (std::strlen(c->c.tcp.source_addr)) {
+  //   std::cout << "source_addr " << std::string(c->c.tcp.source_addr)
+  //             << std::endl;
+  // }
+  // The context object is always freed after the disconnect callback fired.
+  // When a reconnect is needed, the disconnect callback is a good point to do
+  // so.
+}
+
+Status ConnectContext(const std::string &address, int port,
+                      redisAsyncContext **context) {
+  redisAsyncContext *ctx = redisAsyncConnect(address.c_str(), port);
   if (ctx == nullptr || ctx->err) {
     LOG(ERROR) << "Could not establish connection to redis " << address << ":"
                << port;
     return Status::IOError("ERR");
   }
+  CHECK(redisAsyncSetDisconnectCallback(
+            ctx, static_cast<redisDisconnectCallback *>(
+                     RedisDisconnectCallback)) == REDIS_OK);
   *context = ctx;
   return Status::OK();
 }
-}  // namespace
+} // namespace
 
-Status RedisClient::Connect(const std::string& address,
-                            int write_port,
+Status RedisClient::Connect(const std::string &address, int write_port,
                             int ack_port) {
   int connection_attempts = 0;
   context_ = redisConnect(address.c_str(), write_port);
@@ -88,7 +142,7 @@ Status RedisClient::Connect(const std::string& address,
     context_ = redisConnect(address.c_str(), write_port);
     connection_attempts += 1;
   }
-  redisReply* reply = reinterpret_cast<redisReply*>(
+  redisReply *reply = reinterpret_cast<redisReply *>(
       redisCommand(context_, "CONFIG SET notify-keyspace-events Kl"));
   REDIS_CHECK_ERROR(context_, reply);
 
@@ -99,26 +153,38 @@ Status RedisClient::Connect(const std::string& address,
   return Status::OK();
 }
 
-Status RedisClient::Connect(const std::string& address, int port) {
+Status RedisClient::ReconnectAckContext(const std::string &address, int port,
+                                        redisCallbackFn *callback) {
+  redisAsyncDisconnect(read_context_);
+  redisAsyncDisconnect(ack_subscribe_context_);
+  CHECK(ConnectContext(address, port, &read_context_).ok());
+  CHECK(ConnectContext(address, port, &ack_subscribe_context_).ok());
+  return RegisterAckCallback(callback);
+}
+
+Status RedisClient::Connect(const std::string &address, int port) {
   return Connect(address, port, port);
 }
 
-Status RedisClient::AttachToEventLoop(aeEventLoop* loop) {
+Status RedisClient::AttachToEventLoop(aeEventLoop *loop) {
+  loop_ = loop;
   if (redisAeAttach(loop, write_context_) != REDIS_OK) {
     return Status::IOError("could not attach redis event loop");
   }
   if (redisAeAttach(loop, read_context_) != REDIS_OK) {
     return Status::IOError("could not attach redis event loop");
   }
-  if (redisAeAttach(loop, ack_subscribe_context_) != REDIS_OK) {
-    return Status::IOError("could not attach redis event loop");
-  }
   return Status::OK();
 }
-// reinterpret_cast<redisCallbackFn *>
-Status RedisClient::RegisterAckCallback(redisCallbackFn* callback) {
-  // static const char* kChan = "answers";
-  const std::string kChan = std::to_string(getpid());
+
+static const std::string kChan = std::to_string(getpid());
+
+Status RedisClient::RegisterAckCallback(redisCallbackFn *callback) {
+  CHECK(loop_ != nullptr);
+  if (redisAeAttach(loop_, ack_subscribe_context_) != REDIS_OK) {
+    return Status::IOError("could not attach redis event loop");
+  }
+
   LOG(INFO) << getpid() << " subscribing to chan " << kChan;
   const int status = redisAsyncCommand(ack_subscribe_context_, callback,
                                        /*privdata=*/NULL, "SUBSCRIBE %b",
@@ -129,17 +195,15 @@ Status RedisClient::RegisterAckCallback(redisCallbackFn* callback) {
   return Status::OK();
 }
 
-Status RedisClient::RunAsync(const std::string& command,
-                             const std::string& id,
-                             const char* data,
-                             size_t length,
+Status RedisClient::RunAsync(const std::string &command, const std::string &id,
+                             const char *data, size_t length,
                              int64_t callback_index) {
   if (length > 0) {
     std::string redis_command = command + " %b %b";
     int status = redisAsyncCommand(
         write_context_,
-        reinterpret_cast<redisCallbackFn*>(&GlobalRedisCallback),
-        reinterpret_cast<void*>(callback_index), redis_command.c_str(),
+        reinterpret_cast<redisCallbackFn *>(&GlobalRedisCallback),
+        reinterpret_cast<void *>(callback_index), redis_command.c_str(),
         id.data(), id.size(), data, length);
     if (status == REDIS_ERR) {
       return Status::IOError(std::string(write_context_->errstr));
@@ -148,8 +212,8 @@ Status RedisClient::RunAsync(const std::string& command,
     std::string redis_command = command + " %b";
     int status = redisAsyncCommand(
         write_context_,
-        reinterpret_cast<redisCallbackFn*>(&GlobalRedisCallback),
-        reinterpret_cast<void*>(callback_index), redis_command.c_str(),
+        reinterpret_cast<redisCallbackFn *>(&GlobalRedisCallback),
+        reinterpret_cast<void *>(callback_index), redis_command.c_str(),
         id.data(), id.size());
     if (status == REDIS_ERR) {
       return Status::IOError(std::string(write_context_->errstr));

--- a/src/client.h
+++ b/src/client.h
@@ -64,7 +64,6 @@ class RedisClient {
                              redisCallbackFn* callback);
 
   // Does not transfer ownership.
-  redisContext* context() const { return context_; };
   redisAsyncContext* write_context() const { return write_context_; };
   redisAsyncContext* read_context() const { return read_context_; };
 
@@ -73,7 +72,6 @@ class RedisClient {
   // to the loop.  Not owned.
   aeEventLoop* loop_ = nullptr;
 
-  redisContext* context_ = nullptr;
   redisAsyncContext* write_context_ = nullptr;
   redisAsyncContext* read_context_ = nullptr;
   redisAsyncContext* ack_subscribe_context_ = nullptr;

--- a/src/client.h
+++ b/src/client.h
@@ -20,19 +20,19 @@ extern "C" {
 using Status = leveldb::Status;
 
 class RedisCallbackManager {
-public:
-  using RedisCallback = std::function<void(const std::string &)>;
+ public:
+  using RedisCallback = std::function<void(const std::string&)>;
 
-  static RedisCallbackManager &instance() {
+  static RedisCallbackManager& instance() {
     static RedisCallbackManager instance;
     return instance;
   }
 
-  int64_t add(const RedisCallback &function);
+  int64_t add(const RedisCallback& function);
 
-  RedisCallback &get(int64_t callback_index);
+  RedisCallback& get(int64_t callback_index);
 
-private:
+ private:
   RedisCallbackManager() : num_callbacks(0){};
 
   ~RedisCallbackManager() {}
@@ -42,36 +42,41 @@ private:
 };
 
 class RedisClient {
-public:
+ public:
   RedisClient() {}
   ~RedisClient();
+
   // TODO: this should really be (addr, port) pairs.
   // Allows using different ports for write and ack.
-  Status Connect(const std::string &address, int write_port, int ack_port);
+  Status Connect(const std::string& address, int write_port, int ack_port);
   // Use the same port for both write and ack.
-  Status Connect(const std::string &address, int port);
-  Status AttachToEventLoop(aeEventLoop *loop);
-  Status RegisterAckCallback(redisCallbackFn *callback);
-  Status RunAsync(const std::string &command, const std::string &id,
-                  const char *data, size_t length, int64_t callback_index);
+  Status Connect(const std::string& address, int port);
 
-  Status ReconnectAckContext(const std::string &address, int port,
-                             redisCallbackFn *callback);
+  Status ConnectHead(const std::string& address, int port);
+  Status ConnectTail(const std::string& address, int port);
+
+  Status AttachToEventLoop(aeEventLoop* loop);
+  Status RegisterAckCallback(redisCallbackFn* callback);
+  Status RunAsync(const std::string& command, const std::string& id,
+                  const char* data, size_t length, int64_t callback_index);
+
+  Status ReconnectAckContext(const std::string& address, int port,
+                             redisCallbackFn* callback);
 
   // Does not transfer ownership.
-  redisContext *context() const { return context_; };
-  redisAsyncContext *write_context() const { return write_context_; };
-  redisAsyncContext *read_context() const { return read_context_; };
+  redisContext* context() const { return context_; };
+  redisAsyncContext* write_context() const { return write_context_; };
+  redisAsyncContext* read_context() const { return read_context_; };
 
-private:
+ private:
   // Cache user-supplied loop in case we need to attach new/reconnected contexts
   // to the loop.  Not owned.
-  aeEventLoop *loop_;
+  aeEventLoop* loop_;
 
-  redisContext *context_;
-  redisAsyncContext *write_context_;
-  redisAsyncContext *read_context_;
-  redisAsyncContext *ack_subscribe_context_;
+  redisContext* context_;
+  redisAsyncContext* write_context_;
+  redisAsyncContext* read_context_;
+  redisAsyncContext* ack_subscribe_context_;
 };
 
-#endif // CREDIS_CLIENT_H_
+#endif  // CREDIS_CLIENT_H_

--- a/src/client.h
+++ b/src/client.h
@@ -20,19 +20,19 @@ extern "C" {
 using Status = leveldb::Status;
 
 class RedisCallbackManager {
- public:
-  using RedisCallback = std::function<void(const std::string&)>;
+public:
+  using RedisCallback = std::function<void(const std::string &)>;
 
-  static RedisCallbackManager& instance() {
+  static RedisCallbackManager &instance() {
     static RedisCallbackManager instance;
     return instance;
   }
 
-  int64_t add(const RedisCallback& function);
+  int64_t add(const RedisCallback &function);
 
-  RedisCallback& get(int64_t callback_index);
+  RedisCallback &get(int64_t callback_index);
 
- private:
+private:
   RedisCallbackManager() : num_callbacks(0){};
 
   ~RedisCallbackManager() {}
@@ -42,32 +42,36 @@ class RedisCallbackManager {
 };
 
 class RedisClient {
- public:
+public:
   RedisClient() {}
   ~RedisClient();
   // TODO: this should really be (addr, port) pairs.
   // Allows using different ports for write and ack.
-  Status Connect(const std::string& address, int write_port, int ack_port);
+  Status Connect(const std::string &address, int write_port, int ack_port);
   // Use the same port for both write and ack.
-  Status Connect(const std::string& address, int port);
-  Status AttachToEventLoop(aeEventLoop* loop);
-  Status RegisterAckCallback(redisCallbackFn* callback);
-  Status RunAsync(const std::string& command,
-                  const std::string& id,
-                  const char* data,
-                  size_t length,
-                  int64_t callback_index);
+  Status Connect(const std::string &address, int port);
+  Status AttachToEventLoop(aeEventLoop *loop);
+  Status RegisterAckCallback(redisCallbackFn *callback);
+  Status RunAsync(const std::string &command, const std::string &id,
+                  const char *data, size_t length, int64_t callback_index);
+
+  Status ReconnectAckContext(const std::string &address, int port,
+                             redisCallbackFn *callback);
 
   // Does not transfer ownership.
-  redisContext* context() const { return context_; };
-  redisAsyncContext* write_context() const { return write_context_; };
-  redisAsyncContext* read_context() const { return read_context_; };
+  redisContext *context() const { return context_; };
+  redisAsyncContext *write_context() const { return write_context_; };
+  redisAsyncContext *read_context() const { return read_context_; };
 
- private:
-  redisContext* context_;
-  redisAsyncContext* write_context_;
-  redisAsyncContext* read_context_;
-  redisAsyncContext* ack_subscribe_context_;
+private:
+  // Cache user-supplied loop in case we need to attach new/reconnected contexts
+  // to the loop.  Not owned.
+  aeEventLoop *loop_;
+
+  redisContext *context_;
+  redisAsyncContext *write_context_;
+  redisAsyncContext *read_context_;
+  redisAsyncContext *ack_subscribe_context_;
 };
 
-#endif  // CREDIS_CLIENT_H_
+#endif // CREDIS_CLIENT_H_

--- a/src/client.h
+++ b/src/client.h
@@ -71,12 +71,12 @@ class RedisClient {
  private:
   // Cache user-supplied loop in case we need to attach new/reconnected contexts
   // to the loop.  Not owned.
-  aeEventLoop* loop_;
+  aeEventLoop* loop_ = nullptr;
 
-  redisContext* context_;
-  redisAsyncContext* write_context_;
-  redisAsyncContext* read_context_;
-  redisAsyncContext* ack_subscribe_context_;
+  redisContext* context_ = nullptr;
+  redisAsyncContext* write_context_ = nullptr;
+  redisAsyncContext* read_context_ = nullptr;
+  redisAsyncContext* ack_subscribe_context_ = nullptr;
 };
 
 #endif  // CREDIS_CLIENT_H_

--- a/src/credis_parput_bench.cc
+++ b/src/credis_parput_bench.cc
@@ -106,8 +106,8 @@ int main() {
   aeMain(loop);
   LOG(INFO) << "ending loop";
   auto end = std::chrono::system_clock::now();
-  CHECK(num_completed == N)
-      << "num_completed " << num_completed << " vs N " << N;
+  CHECK(num_completed == N) << "num_completed " << num_completed << " vs N "
+                            << N;
 
   const float latency_sum = Sum(latencies);
   const float latency_mean = latency_sum / N;

--- a/src/credis_seqput_bench.cc
+++ b/src/credis_seqput_bench.cc
@@ -202,7 +202,7 @@ void AsyncGet() {
   reads_timer.TimeOpBegin();
   const int status = redisAsyncCommand(
       read_context, reinterpret_cast<redisCallbackFn*>(&SeqGetCallback),
-      /*privdata=*/NULL, "GET %b", last_issued_read_key.data(),
+      /*privdata=*/NULL, "READ %b", last_issued_read_key.data(),
       last_issued_read_key.size());
   CHECK(status == REDIS_OK);
 }

--- a/src/credis_seqput_bench.cc
+++ b/src/credis_seqput_bench.cc
@@ -142,8 +142,8 @@ void SeqPutCallback(redisAsyncContext* write_context,  // != ack_context.
     // generate arbitrary seqnums, not just nonnegative numbers.  Although,
     // hiredis / redis might have undiscovered issues with a redis module
     // command not replying anything...)
-    CHECK(assigned_seqnum >= writes_completed) << assigned_seqnum << " "
-                                               << writes_completed;
+    CHECK(assigned_seqnum >= writes_completed)
+        << assigned_seqnum << " " << writes_completed;
     last_unacked_seqnum = assigned_seqnum;
     assigned_seqnums.insert(assigned_seqnum);
   }
@@ -206,8 +206,8 @@ void SeqGetCallback(redisAsyncContext* /*context*/, void* r,
   // LOG(INFO) << "reply type " << reply->type << "; issued get "
   //           << last_issued_read_key;
   const std::string actual = std::string(reply->str, reply->len);
-  CHECK(last_issued_read_key == actual) << "; expected " << last_issued_read_key
-                                        << " actual " << actual;
+  CHECK(last_issued_read_key == actual)
+      << "; expected " << last_issued_read_key << " actual " << actual;
   OnCompleteLaunchNext(&reads_timer, &reads_completed, writes_completed);
 }
 

--- a/src/credis_seqput_bench.cc
+++ b/src/credis_seqput_bench.cc
@@ -366,13 +366,13 @@ int main(int argc, char** argv) {
   if (argc > 2) kWriteRatio = std::stod(argv[2]);
   int write_port = 6370;
   int ack_port = write_port + num_chain_nodes - 1;
-  std::string head_server = "127.0.0.1", tail_server = "127.0.0.1";
+  std::string head_server = "127.0.0.1";
   if (argc > 3) head_server = std::string(argv[3]);
   if (argc > 4) N = std::stoi(argv[4]);
+  std::string tail_server = head_server;  // By default launch on same server.
   if (argc > 5) {
     tail_server = std::string(argv[5]);
     CHECK(num_chain_nodes == 2);
-    ack_port = 6370;
   }
   LOG(INFO) << "num_chain_nodes " << num_chain_nodes << " write_port "
             << write_port << " ack_port " << ack_port << " write_ratio "

--- a/src/master.cc
+++ b/src/master.cc
@@ -101,6 +101,11 @@ Status SetRole(redisContext* context, const std::string& role,
   }
 }
 
+// TODO(zongheng): as it's currently implemented, MemberReplicate is NOT
+// synchronous at the moment, so this presents a race. E.g., state transfer is
+// still underway to the new tail, but step (3) below has already issued namely
+// telling the new tail to start serving reads.
+
 // Handling node addition at the end of chain.
 //
 // We follow the protocol outlined at the end of Section 3 of the paper.

--- a/src/master.cc
+++ b/src/master.cc
@@ -51,8 +51,7 @@ using Status = leveldb::Status;  // So that it can be easily replaced.
 namespace {
 
 // Handle failure for redis module command as caller, hiredis context as callee.
-int ReplyIfFailure(RedisModuleCtx* rm_ctx,
-                   redisContext* ctx,
+int ReplyIfFailure(RedisModuleCtx* rm_ctx, redisContext* ctx,
                    redisReply* reply) {
   if (reply == NULL) {
     return RedisModule_ReplyWithError(rm_ctx, ctx->errstr);
@@ -63,14 +62,10 @@ int ReplyIfFailure(RedisModuleCtx* rm_ctx,
 
 }  // anonymous namespace
 
-Status SetRole(redisContext* context,
-               const std::string& role,
-               const std::string& prev_address,
-               const std::string& prev_port,
-               const std::string& next_address,
-               const std::string& next_port,
-               long long* sn_result,
-               long long sn = -1,
+Status SetRole(redisContext* context, const std::string& role,
+               const std::string& prev_address, const std::string& prev_port,
+               const std::string& next_address, const std::string& next_port,
+               long long* sn_result, long long sn = -1,
                long long drop_writes = 0) {
   const std::string sn_string = std::to_string(sn);
   const std::string drop_writes_string = std::to_string(drop_writes);
@@ -118,8 +113,7 @@ Status SetRole(redisContext* context,
 // Add a new replica to the chain
 // argv[1] is the IP address of the replica to be added
 // argv[2] is the port of the replica to be added
-int MasterAdd_RedisCommand(RedisModuleCtx* ctx,
-                           RedisModuleString** argv,
+int MasterAdd_RedisCommand(RedisModuleCtx* ctx, RedisModuleString** argv,
                            int argc) {
   if (argc != 3) {
     return RedisModule_WrongArity(ctx);
@@ -259,8 +253,7 @@ int MasterAdd_RedisCommand(RedisModuleCtx* ctx,
 //
 // Returns, as a string, "<new head addr>:<new head port>".
 int MasterRefreshHead_RedisCommand(RedisModuleCtx* ctx,
-                                   RedisModuleString** argv,
-                                   int argc) {
+                                   RedisModuleString** argv, int argc) {
   REDISMODULE_NOT_USED(argv);
   if (argc != 1) {
     return RedisModule_WrongArity(ctx);
@@ -304,8 +297,7 @@ int MasterRefreshHead_RedisCommand(RedisModuleCtx* ctx,
 // MASTER.REFRESH_TAIL: similar to MASTER.REFRESH_HEAD, but for getting the
 // up-to-date tail.
 int MasterRefreshTail_RedisCommand(RedisModuleCtx* ctx,
-                                   RedisModuleString** argv,
-                                   int argc) {
+                                   RedisModuleString** argv, int argc) {
   REDISMODULE_NOT_USED(argv);
   if (argc != 1) {
     return RedisModule_WrongArity(ctx);
@@ -344,8 +336,7 @@ int MasterRefreshTail_RedisCommand(RedisModuleCtx* ctx,
 }
 
 // Return the current view of the chain.
-int MasterGetChain_RedisCommand(RedisModuleCtx* ctx,
-                                RedisModuleString** argv,
+int MasterGetChain_RedisCommand(RedisModuleCtx* ctx, RedisModuleString** argv,
                                 int argc) {
   REDISMODULE_NOT_USED(argv);
   if (argc != 1) return RedisModule_WrongArity(ctx);
@@ -360,8 +351,7 @@ int MasterGetChain_RedisCommand(RedisModuleCtx* ctx,
   return REDISMODULE_OK;
 }
 
-int MasterTest_RedisCommand(RedisModuleCtx* ctx,
-                            RedisModuleString** argv,
+int MasterTest_RedisCommand(RedisModuleCtx* ctx, RedisModuleString** argv,
                             int argc) {
   if (argc != 1) {
     return RedisModule_WrongArity(ctx);
@@ -383,8 +373,7 @@ int MasterTest_RedisCommand(RedisModuleCtx* ctx,
 
 extern "C" {
 
-int RedisModule_OnLoad(RedisModuleCtx* ctx,
-                       RedisModuleString** argv,
+int RedisModule_OnLoad(RedisModuleCtx* ctx, RedisModuleString** argv,
                        int argc) {
   FLAGS_logtostderr = 1;  // By default glog uses log files in /tmp.
   ::google::InitGoogleLogging("libmaster");

--- a/src/master.cc
+++ b/src/master.cc
@@ -272,6 +272,8 @@ int MasterAdd_RedisCommand(RedisModuleCtx* ctx, RedisModuleString** argv,
 // first.  We should enforce the contract that the Refresh calls are performed
 // only when clients detect disconnects.  The calls should forcibly remove the
 // head/tail.  Otherwise race conditions arise.
+// TODO(zongheng): after a month of originally writing the above, I don't
+// understand it anymore.
 
 // MASTER.REFRESH_HEAD: return the current head if non-faulty, otherwise
 // designate the child of the old head as the new head.

--- a/src/master.cc
+++ b/src/master.cc
@@ -268,6 +268,11 @@ int MasterAdd_RedisCommand(RedisModuleCtx* ctx, RedisModuleString** argv,
 //   return RedisModule_ReplyWithNull(ctx);
 // }
 
+// TODO(zongheng): I think it's incorrect in Refresh{Head,Tail} to reconnect
+// first.  We should enforce the contract that the Refresh calls are performed
+// only when clients detect disconnects.  The calls should forcibly remove the
+// head/tail.  Otherwise race conditions arise.
+
 // MASTER.REFRESH_HEAD: return the current head if non-faulty, otherwise
 // designate the child of the old head as the new head.
 //

--- a/src/master_client.cc
+++ b/src/master_client.cc
@@ -2,8 +2,6 @@
 
 #include "glog/logging.h"
 
-// #include "utils.h"
-
 extern "C" {
 #include "hiredis/async.h"
 #include "hiredis/hiredis.h"

--- a/src/master_client.cc
+++ b/src/master_client.cc
@@ -2,21 +2,43 @@
 
 #include "glog/logging.h"
 
-#include "utils.h"
+// #include "utils.h"
 
-Status RedisMasterClient::Connect(const std::string& address, int port) {
+extern "C" {
+#include "hiredis/async.h"
+#include "hiredis/hiredis.h"
+}
+
+namespace {
+redisContext *SyncConnect(const std::string &address, int port) {
+  struct timeval timeout = {1, 500000}; // 1.5 seconds
+  redisContext *c = redisConnectWithTimeout(address.c_str(), port, timeout);
+  if (c == NULL || c->err) {
+    if (c) {
+      printf("Connection error: %s\n", c->errstr);
+      redisFree(c);
+    } else {
+      printf("Connection error: can't allocate redis context\n");
+    }
+    std::exit(1);
+  }
+  return c;
+}
+} // namespace
+
+Status RedisMasterClient::Connect(const std::string &address, int port) {
   redis_context_.reset(SyncConnect(address, port));
   return Status::OK();
 }
 
-const char* MasterClient::WatermarkKey(Watermark w) const {
+const char *MasterClient::WatermarkKey(Watermark w) const {
   return w == MasterClient::Watermark::kSnCkpt ? "_sn_ckpt" : "_sn_flushed";
 }
 
-Status RedisMasterClient::GetWatermark(Watermark w, int64_t* val) const {
-  redisReply* reply = reinterpret_cast<redisReply*>(
+Status RedisMasterClient::GetWatermark(Watermark w, int64_t *val) const {
+  redisReply *reply = reinterpret_cast<redisReply *>(
       redisCommand(redis_context_.get(), "GET %s", WatermarkKey(w)));
-  const std::string reply_str(reply->str, reply->len);  // Can be optimized
+  const std::string reply_str(reply->str, reply->len); // Can be optimized
   const int reply_type = reply->type;
   freeReplyObject(reply);
 
@@ -34,19 +56,19 @@ Status RedisMasterClient::GetWatermark(Watermark w, int64_t* val) const {
     return Status::OK();
   }
 
-  *val = *reinterpret_cast<const int64_t*>(reply_str.data());
+  *val = *reinterpret_cast<const int64_t *>(reply_str.data());
   DLOG(INFO) << "GET " << WatermarkKey(w) << ": " << *val;
   return Status::OK();
 }
 
 Status RedisMasterClient::SetWatermark(Watermark w, int64_t new_val) {
-  const char* new_val_data = reinterpret_cast<const char*>(&new_val);
+  const char *new_val_data = reinterpret_cast<const char *>(&new_val);
 
-  redisReply* reply = reinterpret_cast<redisReply*>(
+  redisReply *reply = reinterpret_cast<redisReply *>(
       redisCommand(redis_context_.get(), "SET %s %b", WatermarkKey(w),
                    new_val_data, sizeof(int64_t)));
 
-  std::string reply_str(reply->str, reply->len);  // Can be optimized
+  std::string reply_str(reply->str, reply->len); // Can be optimized
   DLOG(INFO) << "SET " << WatermarkKey(w) << " " << new_val << ": "
              << reply_str;
   CHECK(reply_str == "OK");
@@ -55,11 +77,26 @@ Status RedisMasterClient::SetWatermark(Watermark w, int64_t new_val) {
   return Status::OK();
 }
 
-Status RedisMasterClient::Head(std::string* address, int* port) {
+Status RedisMasterClient::Head(std::string *address, int *port) {
   CHECK(false) << "Not implemented";
   return Status::NotSupported("Not implemented");
 }
-Status RedisMasterClient::Tail(std::string* address, int* port) {
-  CHECK(false) << "Not implemented";
-  return Status::NotSupported("Not implemented");
+Status RedisMasterClient::Tail(std::string *address, int *port) {
+  LOG(INFO) << "Issuing RefreshTail";
+  redisReply *reply = reinterpret_cast<redisReply *>(
+      redisCommand(redis_context_.get(), "MASTER.REFRESH_TAIL"));
+
+  CHECK(reply != nullptr) << "Error from redisCommand(): code "
+                          << redis_context_->err << ", "
+                          << std::string(redis_context_->errstr);
+
+  std::string reply_str(reply->str, reply->len);
+  LOG(INFO) << "RefreshTail result: " << reply_str;
+  freeReplyObject(reply);
+
+  const size_t pos = reply_str.find_first_of(':');
+  CHECK(pos != std::string::npos);
+  *address = reply_str.substr(0, pos);
+  *port = std::atoi(reply_str.substr(pos + 1).data());
+  return Status::OK();
 }

--- a/src/master_client.cc
+++ b/src/master_client.cc
@@ -10,9 +10,9 @@ extern "C" {
 }
 
 namespace {
-redisContext *SyncConnect(const std::string &address, int port) {
-  struct timeval timeout = {1, 500000}; // 1.5 seconds
-  redisContext *c = redisConnectWithTimeout(address.c_str(), port, timeout);
+redisContext* SyncConnect(const std::string& address, int port) {
+  struct timeval timeout = {1, 500000};  // 1.5 seconds
+  redisContext* c = redisConnectWithTimeout(address.c_str(), port, timeout);
   if (c == NULL || c->err) {
     if (c) {
       printf("Connection error: %s\n", c->errstr);
@@ -24,51 +24,51 @@ redisContext *SyncConnect(const std::string &address, int port) {
   }
   return c;
 }
-} // namespace
+}  // namespace
 
-Status RedisMasterClient::Connect(const std::string &address, int port) {
+Status RedisMasterClient::Connect(const std::string& address, int port) {
   redis_context_.reset(SyncConnect(address, port));
   return Status::OK();
 }
 
-const char *MasterClient::WatermarkKey(Watermark w) const {
+const char* MasterClient::WatermarkKey(Watermark w) const {
   return w == MasterClient::Watermark::kSnCkpt ? "_sn_ckpt" : "_sn_flushed";
 }
 
-Status RedisMasterClient::GetWatermark(Watermark w, int64_t *val) const {
-  redisReply *reply = reinterpret_cast<redisReply *>(
+Status RedisMasterClient::GetWatermark(Watermark w, int64_t* val) const {
+  redisReply* reply = reinterpret_cast<redisReply*>(
       redisCommand(redis_context_.get(), "GET %s", WatermarkKey(w)));
-  const std::string reply_str(reply->str, reply->len); // Can be optimized
+  const std::string reply_str(reply->str, reply->len);  // Can be optimized
   const int reply_type = reply->type;
   freeReplyObject(reply);
 
   if (reply_type == REDIS_REPLY_NIL) {
     switch (w) {
-    case Watermark::kSnCkpt:
-      *val = kSnCkptInit;
-      break;
-    case Watermark::kSnFlushed:
-      *val = kSnFlushedInit;
-      break;
-    default:
-      return Status::InvalidArgument("Watermark type incorrect");
+      case Watermark::kSnCkpt:
+        *val = kSnCkptInit;
+        break;
+      case Watermark::kSnFlushed:
+        *val = kSnFlushedInit;
+        break;
+      default:
+        return Status::InvalidArgument("Watermark type incorrect");
     }
     return Status::OK();
   }
 
-  *val = *reinterpret_cast<const int64_t *>(reply_str.data());
+  *val = *reinterpret_cast<const int64_t*>(reply_str.data());
   DLOG(INFO) << "GET " << WatermarkKey(w) << ": " << *val;
   return Status::OK();
 }
 
 Status RedisMasterClient::SetWatermark(Watermark w, int64_t new_val) {
-  const char *new_val_data = reinterpret_cast<const char *>(&new_val);
+  const char* new_val_data = reinterpret_cast<const char*>(&new_val);
 
-  redisReply *reply = reinterpret_cast<redisReply *>(
+  redisReply* reply = reinterpret_cast<redisReply*>(
       redisCommand(redis_context_.get(), "SET %s %b", WatermarkKey(w),
                    new_val_data, sizeof(int64_t)));
 
-  std::string reply_str(reply->str, reply->len); // Can be optimized
+  std::string reply_str(reply->str, reply->len);  // Can be optimized
   DLOG(INFO) << "SET " << WatermarkKey(w) << " " << new_val << ": "
              << reply_str;
   CHECK(reply_str == "OK");
@@ -77,13 +77,13 @@ Status RedisMasterClient::SetWatermark(Watermark w, int64_t new_val) {
   return Status::OK();
 }
 
-Status RedisMasterClient::Head(std::string *address, int *port) {
+Status RedisMasterClient::Head(std::string* address, int* port) {
   CHECK(false) << "Not implemented";
   return Status::NotSupported("Not implemented");
 }
-Status RedisMasterClient::Tail(std::string *address, int *port) {
+Status RedisMasterClient::Tail(std::string* address, int* port) {
   LOG(INFO) << "Issuing RefreshTail";
-  redisReply *reply = reinterpret_cast<redisReply *>(
+  redisReply* reply = reinterpret_cast<redisReply*>(
       redisCommand(redis_context_.get(), "MASTER.REFRESH_TAIL"));
 
   CHECK(reply != nullptr) << "Error from redisCommand(): code "

--- a/src/member.cc
+++ b/src/member.cc
@@ -294,25 +294,13 @@ int MemberSetRole_RedisCommand(RedisModuleCtx* ctx, RedisModuleString** argv,
     CHECK(role == "");
   }
 
-  std::string prev_address = ReadString(argv[2]);
-  if (prev_address == "") {
-    prev_address = module.prev_address();
-  }
-  std::string prev_port = ReadString(argv[3]);
-  if (prev_port == "") {
-    prev_port = module.prev_port();
-  }
-  std::string next_address = ReadString(argv[4]);
-  if (next_address == "") {
-    next_address = module.next_address();
-  }
-  std::string next_port = ReadString(argv[5]);
-  if (next_port == "") {
-    next_port = module.next_port();
-  }
+  const std::string prev_address = ReadString(argv[2]);
+  const std::string prev_port = ReadString(argv[3]);
+  const std::string next_address = ReadString(argv[4]);
+  const std::string next_port = ReadString(argv[5]);
 
-  DLOG(INFO) << "MemberSetRole args: " << role << " " << prev_address << " "
-             << prev_port << " " << next_address << " " << next_port;
+  LOG(INFO) << "MemberSetRole args: " << role << " " << prev_address << " "
+            << prev_port << " " << next_address << " " << next_port;
 
   module.Reset(prev_address, prev_port, next_address, next_port);
 
@@ -575,12 +563,6 @@ int MemberNoPropBatchedPut_RedisCommand(RedisModuleCtx* ctx,
 int MemberReplicate_RedisCommand(RedisModuleCtx* ctx, RedisModuleString** argv,
                                  int argc) {
   const double start = timer.NowMicrosecs();
-  LOG(INFO) << "In MemberReplicate, argc " << argc;
-  // REDISMODULE_NOT_USED(argv);
-  // if (argc != 1) {
-  //   return RedisModule_WrongArity(ctx);
-  // }
-
   DLOG(INFO) << "has child? " << (module.child() != nullptr);
   // TODO(zongheng): we should cap the size of each send.
   if (module.child() && !module.sn_to_key().empty()) {

--- a/src/member.cc
+++ b/src/member.cc
@@ -858,7 +858,7 @@ int Read_RedisCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
     size_t size = 0;
     const char* value = reader.value(&size);
     return RedisModule_ReplyWithStringBuffer(ctx, value, size);
-  } else {
+  } else if (module.gcs_mode() > RedisChainModule::GcsMode::kNormal) {
     // Fall back to checkpoint file.
     leveldb::DB* ckpt;
     Status s = module.OpenCheckpoint(&ckpt);
@@ -874,6 +874,9 @@ int Read_RedisCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
     }
     HandleNonOk(ctx, s);
     return RedisModule_ReplyWithStringBuffer(ctx, value.data(), value.size());
+  } else {
+    // No checkpoint file, so return nil signaling not found.
+    return RedisModule_ReplyWithNull(ctx);
   }
 }
 

--- a/src/member.cc
+++ b/src/member.cc
@@ -582,6 +582,7 @@ int MemberReplicate_RedisCommand(RedisModuleCtx* ctx, RedisModuleString** argv,
   // }
 
   DLOG(INFO) << "has child? " << (module.child() != nullptr);
+  // TODO(zongheng): we should cap the size of each send.
   if (module.child() && !module.sn_to_key().empty()) {
     DLOG(INFO) << "Called replicate. sn_to_key size "
                << module.sn_to_key().size();
@@ -615,8 +616,8 @@ int MemberReplicate_RedisCommand(RedisModuleCtx* ctx, RedisModuleString** argv,
       ++cnt;
     }
     const std::string blob = ss.str();
-    LOG(INFO) << "num_entries " << num_entries << " blob.size() "
-              << blob.size();
+    LOG(INFO) << "num_entries " << num_entries << " blob.size() " << blob.size()
+              << " or " << blob.size() / (1 << 20) << " MB";
 
     // TODO(zongheng): for now this should probably be synchronous.
     const int status = redisAsyncCommand(
@@ -627,7 +628,6 @@ int MemberReplicate_RedisCommand(RedisModuleCtx* ctx, RedisModuleString** argv,
   }
   const double end = timer.NowMicrosecs();
   const int millis = static_cast<int>((end - start) / 1e3);
-  std::cout << "MemberReplicate took " << millis << " ms";
   LOG(INFO) << "MemberReplicate took " << millis << " ms";
   return RedisModule_ReplyWithLongLong(ctx, millis);
 }

--- a/src/member.cc
+++ b/src/member.cc
@@ -29,7 +29,7 @@ extern "C" {
 Timer timer;
 
 extern "C" {
-aeEventLoop *getEventLoop();
+aeEventLoop* getEventLoop();
 }
 
 // TODO(zongheng): whenever we are about to do redisAsyncCommand(remote, ...),
@@ -43,16 +43,16 @@ RedisChainModule module;
 
 namespace {
 
-int DoFlush(RedisModuleCtx *ctx, int64_t sn_left, int64_t sn_right,
-            int64_t sn_ckpt, const std::vector<std::string> &flushable_keys) {
+int DoFlush(RedisModuleCtx* ctx, int64_t sn_left, int64_t sn_right,
+            int64_t sn_ckpt, const std::vector<std::string>& flushable_keys) {
   CHECK(module.gcs_mode() == RedisChainModule::GcsMode::kCkptFlush);
 
   const int64_t old = module.key_to_sn().size();
 
-  for (const std::string &key : flushable_keys) {
-    RedisModuleString *rms =
+  for (const std::string& key : flushable_keys) {
+    RedisModuleString* rms =
         RedisModule_CreateString(ctx, key.data(), key.size());
-    RedisModuleKey *rmkey = reinterpret_cast<RedisModuleKey *>(
+    RedisModuleKey* rmkey = reinterpret_cast<RedisModuleKey*>(
         RedisModule_OpenKey(ctx, rms, REDISMODULE_READ | REDISMODULE_WRITE));
     CHECK(REDISMODULE_OK == RedisModule_DeleteKey(rmkey));
     RedisModule_CloseKey(rmkey);
@@ -126,14 +126,14 @@ int DoFlush(RedisModuleCtx *ctx, int64_t sn_left, int64_t sn_right,
 // Collect all keys with sn in [sn_left, sn_right), and that are not dirty
 // w.r.t. sn_ckpt.
 void CollectFlushableKeys(int64_t sn_left, int64_t sn_right, int64_t sn_ckpt,
-                          std::vector<std::string> *flushable_keys) {
-  const auto &sn_to_key = module.sn_to_key();
-  const auto &key_to_sn = module.key_to_sn();
+                          std::vector<std::string>* flushable_keys) {
+  const auto& sn_to_key = module.sn_to_key();
+  const auto& key_to_sn = module.key_to_sn();
 
   for (int64_t seqnum = sn_left; seqnum < sn_right; ++seqnum) {
     const auto it = sn_to_key.find(seqnum);
     CHECK(it != sn_to_key.end());
-    const std::string &key_str(it->second);
+    const std::string& key_str(it->second);
     const auto it_keytosn = key_to_sn.find(key_str);
 
     if (it_keytosn == key_to_sn.end()) {
@@ -163,12 +163,12 @@ void CollectFlushableKeys(int64_t sn_left, int64_t sn_right, int64_t sn_ckpt,
 //
 // For tail: publish that the request has been finalized, and ack up to the
 // chain.
-int Put(RedisModuleCtx *ctx, RedisModuleString *name, RedisModuleString *data,
-        RedisModuleString *client_id, long long sn) {
-  RedisModuleKey *key = reinterpret_cast<RedisModuleKey *>(
+int Put(RedisModuleCtx* ctx, RedisModuleString* name, RedisModuleString* data,
+        RedisModuleString* client_id, long long sn) {
+  RedisModuleKey* key = reinterpret_cast<RedisModuleKey*>(
       RedisModule_OpenKey(ctx, name, REDISMODULE_WRITE));
-  CHECK(REDISMODULE_OK == RedisModule_StringSet(key, data))
-      << "key " << key << " sn " << sn;
+  CHECK(REDISMODULE_OK == RedisModule_StringSet(key, data)) << "key " << key
+                                                            << " sn " << sn;
   RedisModule_CloseKey(key);
 
   // State maintenance.
@@ -195,13 +195,13 @@ int Put(RedisModuleCtx *ctx, RedisModuleString *name, RedisModuleString *data,
     //      return RedisModule_ReplyWithCallReply(ctx, reply);
     //    }
 
-    RedisModuleString *s =
+    RedisModuleString* s =
         RedisModule_CreateString(ctx, seqnum_str.data(), seqnum_str.size());
     RedisModule_Publish(client_id, s);
     RedisModule_FreeString(ctx, s);
 
     if (module.parent()) {
-      RedisModuleCallReply *reply =
+      RedisModuleCallReply* reply =
           RedisModule_Call(ctx, "MEMBER.ACK", "c", seqnum_str.c_str());
       if (RedisModule_CallReplyType(reply) == REDISMODULE_REPLY_ERROR) {
         return RedisModule_ReplyWithCallReply(ctx, reply);
@@ -216,11 +216,11 @@ int Put(RedisModuleCtx *ctx, RedisModuleString *name, RedisModuleString *data,
     if (!module.child()->err) {
       // Zero-copy.
       size_t key_len = 0;
-      const char *key_ptr = ReadString(name, &key_len);
+      const char* key_ptr = ReadString(name, &key_len);
       size_t val_len = 0;
-      const char *val_ptr = ReadString(data, &val_len);
+      const char* val_ptr = ReadString(data, &val_len);
       size_t cid_len = 0;
-      const char *cid_ptr = ReadString(client_id, &cid_len);
+      const char* cid_ptr = ReadString(client_id, &cid_len);
 
       const int status = redisAsyncCommand(
           module.child(), NULL, NULL, "MEMBER.PROPAGATE %b %b %b %b", key_ptr,
@@ -251,7 +251,7 @@ int Put(RedisModuleCtx *ctx, RedisModuleString *name, RedisModuleString *data,
   return REDISMODULE_OK;
 }
 
-} // namespace
+}  // namespace
 
 // Set the role, successor and predecessor of this server.
 // Each of the arguments can be the empty string, in which case it is not set.
@@ -265,7 +265,7 @@ int Put(RedisModuleCtx *ctx, RedisModuleString *name, RedisModuleString *data,
 //     removal) and -1 if no node is removed
 // argv[7]: drop_writes?
 // Returns the latest sequence number on this node
-int MemberSetRole_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
+int MemberSetRole_RedisCommand(RedisModuleCtx* ctx, RedisModuleString** argv,
                                int argc) {
   if (argc != 8) {
     return RedisModule_WrongArity(ctx);
@@ -307,21 +307,20 @@ int MemberSetRole_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
 
   if (module.child()) {
     CHECK(!module.child()->err);
-    aeEventLoop *loop = getEventLoop();
+    aeEventLoop* loop = getEventLoop();
     redisAeAttach(loop, module.child());
   }
 
   if (module.parent()) {
     CHECK(!module.parent()->err);
-    aeEventLoop *loop = getEventLoop();
+    aeEventLoop* loop = getEventLoop();
     redisAeAttach(loop, module.parent());
   }
 
   const int64_t first_sn = std::stoi(ReadString(argv[6]));
   const bool drop_writes = std::stoi(ReadString(argv[7])) ? true : false;
   LOG(INFO) << "In MemberSetRole drop_writes: " << drop_writes;
-  if (drop_writes)
-    module.SetDropWrites(drop_writes);
+  if (drop_writes) module.SetDropWrites(drop_writes);
 
   // TODO(zongheng): I don't understand why we do this.
   if (module.child()) {
@@ -331,7 +330,7 @@ int MemberSetRole_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
       std::string key = i->second;
       KeyReader reader(ctx, key);
       size_t size;
-      const char *value = reader.value(&size);
+      const char* value = reader.value(&size);
       if (!module.child()->err) {
         const int status = redisAsyncCommand(
             module.child(), NULL, NULL, "MEMBER.PROPAGATE %b %b %b", key.data(),
@@ -350,18 +349,17 @@ int MemberSetRole_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
   return REDISMODULE_OK;
 }
 
-int MemberConnectToMaster_RedisCommand(RedisModuleCtx *ctx,
-                                       RedisModuleString **argv, int argc) {
+int MemberConnectToMaster_RedisCommand(RedisModuleCtx* ctx,
+                                       RedisModuleString** argv, int argc) {
   if (argc != 3) {
     return RedisModule_WrongArity(ctx);
   }
   size_t size = 0;
-  const char *ptr = RedisModule_StringPtrLen(argv[1], &size);
+  const char* ptr = RedisModule_StringPtrLen(argv[1], &size);
   long long port = 0;
   RedisModule_StringToLongLong(argv[2], &port);
   Status s = module.ConnectToMaster(std::string(ptr, size), port);
-  if (!s.ok())
-    return RedisModule_ReplyWithError(ctx, s.ToString().data());
+  if (!s.ok()) return RedisModule_ReplyWithError(ctx, s.ToString().data());
   return RedisModule_ReplyWithSimpleString(ctx, "OK");
 }
 
@@ -369,7 +367,7 @@ int MemberConnectToMaster_RedisCommand(RedisModuleCtx *ctx,
 // argv[1] is the key for the data
 // argv[2] is the data
 // argv[3] is unique client id
-int MemberPut_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
+int MemberPut_RedisCommand(RedisModuleCtx* ctx, RedisModuleString** argv,
                            int argc) {
   if (argc != 4) {
     return RedisModule_WrongArity(ctx);
@@ -413,13 +411,13 @@ int MemberPut_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
   }
 }
 
-int NoReply_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
+int NoReply_RedisCommand(RedisModuleCtx* ctx, RedisModuleString** argv,
                          int argc) {
   if (argc != 1) {
     return RedisModule_WrongArity(ctx);
   }
   LOG(INFO) << "Processed NoReply";
-  return 0; // STATUS_OK
+  return 0;  // STATUS_OK
 }
 
 // Propagate a put request down the chain
@@ -427,7 +425,7 @@ int NoReply_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
 // argv[2] is the data
 // argv[3] is the sequence number for this update request
 // argv[4] is unique client id
-int MemberPropagate_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
+int MemberPropagate_RedisCommand(RedisModuleCtx* ctx, RedisModuleString** argv,
                                  int argc) {
   if (argc != 5) {
     return RedisModule_WrongArity(ctx);
@@ -453,7 +451,7 @@ int MemberPropagate_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
 // argv[1]: key
 // argv[2]: val
 // argv[3]: sn
-int MemberNoPropPut_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
+int MemberNoPropPut_RedisCommand(RedisModuleCtx* ctx, RedisModuleString** argv,
                                  int argc) {
   if (argc != 4) {
     return RedisModule_WrongArity(ctx);
@@ -465,7 +463,7 @@ int MemberNoPropPut_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
 
   // Redis state.
   // No propagation: just state maintenance.
-  RedisModuleKey *key = reinterpret_cast<RedisModuleKey *>(
+  RedisModuleKey* key = reinterpret_cast<RedisModuleKey*>(
       RedisModule_OpenKey(ctx, argv[1], REDISMODULE_WRITE));
   RedisModule_StringSet(key, argv[2]);
   RedisModule_CloseKey(key);
@@ -484,7 +482,7 @@ int MemberNoPropPut_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
 // however without handling Sent_T this function should probably be
 // synchronous.
 // TODO(zongheng): fix the note above; correct iff synchronous...
-int MemberReplicate_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
+int MemberReplicate_RedisCommand(RedisModuleCtx* ctx, RedisModuleString** argv,
                                  int argc) {
   REDISMODULE_NOT_USED(argv);
   if (argc != 1) {
@@ -514,8 +512,8 @@ int MemberReplicate_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
     for (auto element : module.sn_to_key()) {
       KeyReader reader(ctx, element.second);
       size_t key_size, value_size;
-      const char *key_data = reader.key(&key_size);
-      const char *value_data = reader.value(&value_size);
+      const char* key_data = reader.key(&key_size);
+      const char* value_data = reader.value(&value_size);
       const std::string sn = std::to_string(element.first);
       ss << key_data << " " << value_data << " " << sn;
       if (cnt + 1 < num_entries) {
@@ -543,7 +541,7 @@ int MemberReplicate_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
 // Send ack up the chain.
 // This could be batched in the future if we want to.
 // argv[1] is the sequence number that is acknowledged
-int MemberAck_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
+int MemberAck_RedisCommand(RedisModuleCtx* ctx, RedisModuleString** argv,
                            int argc) {
   if (argc != 2) {
     return RedisModule_WrongArity(ctx);
@@ -565,11 +563,10 @@ int MemberAck_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
 
 // Let new writes flow through.
 // Used in the node addition code path (see MASTER.ADD).
-int MemberUnblockWrites_RedisCommand(RedisModuleCtx *ctx,
-                                     RedisModuleString **argv, int argc) {
+int MemberUnblockWrites_RedisCommand(RedisModuleCtx* ctx,
+                                     RedisModuleString** argv, int argc) {
   REDISMODULE_NOT_USED(argv);
-  if (argc != 1)
-    return RedisModule_WrongArity(ctx);
+  if (argc != 1) return RedisModule_WrongArity(ctx);
   LOG(INFO) << "Unblocking writes";
   module.SetDropWrites(false);
   return RedisModule_ReplyWithNull(ctx);
@@ -586,11 +583,11 @@ const int kMaxEntriesToFlushOnce = 350000;
 //
 // Returns the number of sequence numbers newly checkpointed.  Errors out if
 // not called on the tail.
-int TailCheckpoint_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
+int TailCheckpoint_RedisCommand(RedisModuleCtx* ctx, RedisModuleString** argv,
                                 int argc) {
   const double start = timer.NowMicrosecs();
   REDISMODULE_NOT_USED(argv);
-  if (argc != 1) { // No arg needed.
+  if (argc != 1) {  // No arg needed.
     return RedisModule_WrongArity(ctx);
   }
   if (!module.ActAsTail()) {
@@ -618,7 +615,7 @@ int TailCheckpoint_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
   // Fill in "redis key -> redis value".
   std::vector<std::string> keys_to_write;
   std::vector<std::string> vals_to_write;
-  const auto &sn_to_key = module.sn_to_key();
+  const auto& sn_to_key = module.sn_to_key();
   size_t size = 0;
   for (int64_t s = sn_ckpt; s <= sn_bound; ++s) {
     auto i = sn_to_key.find(s);
@@ -626,7 +623,7 @@ int TailCheckpoint_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
         << "ERR the sn_to_key map doesn't contain seqnum " << s;
     std::string key = i->second;
     const KeyReader reader(ctx, key);
-    const char *value = reader.value(&size);
+    const char* value = reader.value(&size);
 
     keys_to_write.push_back(key);
     vals_to_write.emplace_back(std::string(value, size));
@@ -638,10 +635,10 @@ int TailCheckpoint_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
     batch.Put(keys_to_write[i], vals_to_write[i]);
   }
   // Open the checkpoint.
-  leveldb::DB *ckpt;
+  leveldb::DB* ckpt;
   s = module.OpenCheckpoint(&ckpt);
   HandleNonOk(ctx, s);
-  std::unique_ptr<leveldb::DB> ptr(ckpt); // RAII.
+  std::unique_ptr<leveldb::DB> ptr(ckpt);  // RAII.
   // TODO(zongheng): tune WriteOptions (sync, compression, etc).
   s = ckpt->Write(leveldb::WriteOptions(), &batch);
   HandleNonOk(ctx, s);
@@ -665,12 +662,11 @@ int TailCheckpoint_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
 // Replies to the client # of keys removed from redis state, including 0.
 //
 // Errors out if not called on the head, or if GcsMode is not kCkptFlush.
-int HeadFlush_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
+int HeadFlush_RedisCommand(RedisModuleCtx* ctx, RedisModuleString** argv,
                            int argc) {
   const double start = timer.NowMicrosecs();
   REDISMODULE_NOT_USED(argv);
-  if (argc != 1)
-    return RedisModule_WrongArity(ctx); // No args needed.
+  if (argc != 1) return RedisModule_WrongArity(ctx);  // No args needed.
   if (!module.ActAsHead()) {
     return RedisModule_ReplyWithError(
         ctx, "ERR this command must be called on the head.");
@@ -706,10 +702,9 @@ int HeadFlush_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
 // Internal command that propagates a flush.  Users should never call.
 // Args, all required and are int:
 //   <sn_left>  <sn_right>  <sn_ckpt>
-int MemberFlush_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
+int MemberFlush_RedisCommand(RedisModuleCtx* ctx, RedisModuleString** argv,
                              int argc) {
-  if (argc != 4)
-    return RedisModule_WrongArity(ctx);
+  if (argc != 4) return RedisModule_WrongArity(ctx);
 
   long long sn_left, sn_right, sn_ckpt;
   RedisModule_StringToLongLong(argv[1], &sn_left);
@@ -727,19 +722,19 @@ int MemberFlush_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
 // LIST.CHECKPOINT: print to stdout all keys, values in the checkpoint file.
 //
 // For debugging.
-int ListCheckpoint_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
+int ListCheckpoint_RedisCommand(RedisModuleCtx* ctx, RedisModuleString** argv,
                                 int argc) {
   REDISMODULE_NOT_USED(argv);
-  if (argc != 1) { // No arg needed.
+  if (argc != 1) {  // No arg needed.
     return RedisModule_WrongArity(ctx);
   }
-  leveldb::DB *ckpt;
+  leveldb::DB* ckpt;
   Status s = module.OpenCheckpoint(&ckpt);
   HandleNonOk(ctx, s);
-  std::unique_ptr<leveldb::DB> ptr(ckpt); // RAII.
+  std::unique_ptr<leveldb::DB> ptr(ckpt);  // RAII.
   // LOG_EVERY_N(INFO, 999999999) << "-- LIST.CHECKPOINT:";
-  leveldb::Iterator *it = ckpt->NewIterator(leveldb::ReadOptions());
-  std::unique_ptr<leveldb::Iterator> iptr(it); // RAII.
+  leveldb::Iterator* it = ckpt->NewIterator(leveldb::ReadOptions());
+  std::unique_ptr<leveldb::Iterator> iptr(it);  // RAII.
   for (it->SeekToFirst(); it->Valid(); it->Next()) {
     if (it->key().ToString() == kCheckpointHeaderKey) {
       // Let's skip the special header for prettier printing.
@@ -754,7 +749,7 @@ int ListCheckpoint_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
 }
 
 // READ: like redis' own GET, but can fall back to checkpoint file.
-int Read_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+int Read_RedisCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc) {
   if (argc != 2) {
     return RedisModule_WrongArity(ctx);
   }
@@ -766,17 +761,17 @@ int Read_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   KeyReader reader(ctx, argv[1]);
   if (!reader.IsEmpty()) {
     size_t size = 0;
-    const char *value = reader.value(&size);
+    const char* value = reader.value(&size);
     return RedisModule_ReplyWithStringBuffer(ctx, value, size);
   } else {
     // Fall back to checkpoint file.
-    leveldb::DB *ckpt;
+    leveldb::DB* ckpt;
     Status s = module.OpenCheckpoint(&ckpt);
     HandleNonOk(ctx, s);
-    std::unique_ptr<leveldb::DB> ptr(ckpt); // RAII.
+    std::unique_ptr<leveldb::DB> ptr(ckpt);  // RAII.
 
     size_t size = 0;
-    const char *key = reader.key(&size);
+    const char* key = reader.key(&size);
     std::string value;
     s = ckpt->Get(leveldb::ReadOptions(), leveldb::Slice(key, size), &value);
     if (s.IsNotFound()) {
@@ -790,10 +785,10 @@ int Read_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 // MEMBER.SN: the largest SN processed by this node.
 //
 // For debugging.
-int MemberSn_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
+int MemberSn_RedisCommand(RedisModuleCtx* ctx, RedisModuleString** argv,
                           int argc) {
   REDISMODULE_NOT_USED(argv);
-  if (argc != 1) { // No arg needed.
+  if (argc != 1) {  // No arg needed.
     return RedisModule_WrongArity(ctx);
   }
   return RedisModule_ReplyWithLongLong(ctx, module.sn());
@@ -806,9 +801,9 @@ extern "C" {
 // If not specified, defaults to kNormal (checkpointing and flushing turned
 // off).
 //   argv[1] indicates the MasterType: 0 for redis (default), 1 for etcd
-int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv,
+int RedisModule_OnLoad(RedisModuleCtx* ctx, RedisModuleString** argv,
                        int argc) {
-  FLAGS_logtostderr = 1; // By default glog uses log files in /tmp.
+  FLAGS_logtostderr = 1;  // By default glog uses log files in /tmp.
   ::google::InitGoogleLogging("libmember");
 
   // Init.  Must be at the top.
@@ -823,17 +818,17 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv,
     CHECK_EQ(REDISMODULE_OK, RedisModule_StringToLongLong(argv[0], &gcs_mode));
   }
   switch (gcs_mode) {
-  case 0:
-    module.set_gcs_mode(RedisChainModule::GcsMode::kNormal);
-    break;
-  case 1:
-    module.set_gcs_mode(RedisChainModule::GcsMode::kCkptOnly);
-    break;
-  case 2:
-    module.set_gcs_mode(RedisChainModule::GcsMode::kCkptFlush);
-    break;
-  default:
-    return REDISMODULE_ERR;
+    case 0:
+      module.set_gcs_mode(RedisChainModule::GcsMode::kNormal);
+      break;
+    case 1:
+      module.set_gcs_mode(RedisChainModule::GcsMode::kCkptOnly);
+      break;
+    case 2:
+      module.set_gcs_mode(RedisChainModule::GcsMode::kCkptFlush);
+      break;
+    default:
+      return REDISMODULE_ERR;
   }
   LOG(INFO) << "GcsMode: " << module.gcs_mode_string();
 
@@ -843,14 +838,14 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv,
              RedisModule_StringToLongLong(argv[0], &master_mode));
   }
   switch (master_mode) {
-  case 0:
-    module.set_master_mode(RedisChainModule::MasterMode::kRedis);
-    break;
-  case 1:
-    module.set_master_mode(RedisChainModule::MasterMode::kEtcd);
-    break;
-  default:
-    return REDISMODULE_ERR;
+    case 0:
+      module.set_master_mode(RedisChainModule::MasterMode::kRedis);
+      break;
+    case 1:
+      module.set_master_mode(RedisChainModule::MasterMode::kEtcd);
+      break;
+    default:
+      return REDISMODULE_ERR;
   }
   LOG(INFO) << "GcsMode: " << module.gcs_mode_string();
 
@@ -907,7 +902,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv,
 
   if (RedisModule_CreateCommand(
           ctx, "READ", Read_RedisCommand,
-          "readonly", // TODO(zongheng): is this ok?  It opens the db.
+          "readonly",  // TODO(zongheng): is this ok?  It opens the db.
           /*firstkey=*/-1, /*lastkey=*/-1,
           /*keystep=*/0) == REDISMODULE_ERR) {
     return REDISMODULE_ERR;

--- a/src/redis_decls.h
+++ b/src/redis_decls.h
@@ -22,8 +22,7 @@ extern void REDISMODULE_API_FUNC(RedisModule_CloseKey)(RedisModuleKey* kp);
 extern RedisModuleString* REDISMODULE_API_FUNC(RedisModule_CreateString)(
     RedisModuleCtx* ctx, const char* ptr, size_t len);
 extern char* REDISMODULE_API_FUNC(RedisModule_StringDMA)(RedisModuleKey* key,
-                                                         size_t* len,
-                                                         int mode);
+                                                         size_t* len, int mode);
 extern const char* REDISMODULE_API_FUNC(RedisModule_StringPtrLen)(
     const RedisModuleString* str, size_t* len);
 extern void REDISMODULE_API_FUNC(RedisModule_FreeString)(

--- a/src/redis_parput_bench.cc
+++ b/src/redis_parput_bench.cc
@@ -34,8 +34,8 @@ int main() {
   }
   aeMain(loop);
   auto end = std::chrono::system_clock::now();
-  CHECK(num_completed == N)
-      << "num_completed " << num_completed << " vs N " << N;
+  CHECK(num_completed == N) << "num_completed " << num_completed << " vs N "
+                            << N;
   LOG(INFO) << "ending bench";
 
   const int64_t latency_us =

--- a/src/redis_seqput_bench.cc
+++ b/src/redis_seqput_bench.cc
@@ -41,8 +41,8 @@ void SeqGetCallback(redisAsyncContext* context, void* r, void* /*privdata*/) {
   // LOG(INFO) << "reply type " << reply->type << "; issued get "
   //           << last_issued_read_key;
   const std::string actual = std::string(reply->str, reply->len);
-  CHECK(last_issued_read_key == actual)
-      << "; expected " << last_issued_read_key << " actual " << actual;
+  CHECK(last_issued_read_key == actual) << "; expected " << last_issued_read_key
+                                        << " actual " << actual;
   reads_timer.TimeOpEnd(reads_completed);
   if (writes_completed + reads_completed == N) {
     aeStop(loop);

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -8,18 +8,18 @@
 
 #include "glog/logging.h"
 
-Timer Timer::Merge(Timer &timer1, Timer &timer2) {
+Timer Timer::Merge(Timer& timer1, Timer& timer2) {
   Timer t;
-  auto &lat = t.latency_micros();
-  auto &lat1 = timer1.latency_micros();
-  auto &lat2 = timer2.latency_micros();
+  auto& lat = t.latency_micros();
+  auto& lat1 = timer1.latency_micros();
+  auto& lat2 = timer2.latency_micros();
   lat.reserve(lat1.size() + lat2.size());
   lat.insert(lat.end(), lat1.begin(), lat1.end());
   lat.insert(lat.end(), lat2.begin(), lat2.end());
 
-  auto &timestamps = t.begin_timestamps();
-  auto &timestamps1 = timer1.begin_timestamps();
-  auto &timestamps2 = timer2.begin_timestamps();
+  auto& timestamps = t.begin_timestamps();
+  auto& timestamps1 = timer1.begin_timestamps();
+  auto& timestamps2 = timer2.begin_timestamps();
   timestamps.reserve(timestamps1.size() + timestamps2.size());
   timestamps.insert(timestamps.end(), timestamps1.begin(), timestamps1.end());
   timestamps.insert(timestamps.end(), timestamps2.begin(), timestamps2.end());
@@ -48,29 +48,27 @@ double Timer::TimeOpBegin() {
 void Timer::TimeOpEnd(int num_completed) {
   const double now = NowMicrosecs();
   CHECK(latency_micros_.size() == num_completed - 1);
-  CHECK(begin_timestamps_.size() == num_completed)
-      << begin_timestamps_.size() << " " << num_completed;
+  CHECK(begin_timestamps_.size() == num_completed) << begin_timestamps_.size()
+                                                   << " " << num_completed;
   latency_micros_.push_back(now - begin_timestamps_.back());
 }
 
-void Timer::Stats(double *mean, double *std) const {
+void Timer::Stats(double* mean, double* std) const {
   if (latency_micros_.empty()) {
     *mean = 0;
     *std = 0;
     return;
   }
   double sum = 0;
-  for (const double x : latency_micros_)
-    sum += x;
+  for (const double x : latency_micros_) sum += x;
   *mean = sum / latency_micros_.size();
 
   sum = 0;
-  for (const double x : latency_micros_)
-    sum += (x - *mean) * (x - *mean);
+  for (const double x : latency_micros_) sum += (x - *mean) * (x - *mean);
   *std = std::sqrt(sum / latency_micros_.size());
 }
 
-std::string Timer::ReportStats(const std::string &name) const {
+std::string Timer::ReportStats(const std::string& name) const {
   double mean = 0, std = 0;
   Stats(&mean, &std);
 
@@ -90,7 +88,7 @@ void Timer::DropFirst(int n) {
   latency_micros_.erase(latency_micros_.begin(), latency_micros_.begin() + n);
 }
 
-void Timer::WriteToFile(const std::string &path) const {
+void Timer::WriteToFile(const std::string& path) const {
   CHECK(begin_timestamps_.size() == latency_micros_.size())
       << begin_timestamps_.size() << " " << latency_micros_.size();
   std::ofstream ofs(path);
@@ -103,5 +101,5 @@ void Timer::WriteToFile(const std::string &path) const {
   }
 }
 
-std::vector<double> &Timer::begin_timestamps() { return begin_timestamps_; }
-std::vector<double> &Timer::latency_micros() { return latency_micros_; }
+std::vector<double>& Timer::begin_timestamps() { return begin_timestamps_; }
+std::vector<double>& Timer::latency_micros() { return latency_micros_; }

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -98,6 +98,7 @@ std::string Timer::ReportStats(const std::string& name) const {
 }
 
 void Timer::DropFirst(int n) {
+  if (begin_timestamps_.size() < n) return;
   begin_timestamps_.erase(begin_timestamps_.begin(),
                           begin_timestamps_.begin() + n);
   latency_micros_.erase(latency_micros_.begin(), latency_micros_.begin() + n);

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -1,5 +1,6 @@
 #include "timer.h"
 
+#include <algorithm>
 #include <cmath>
 #include <string>
 
@@ -21,6 +22,13 @@ void Timer::ToFile(const std::string& path, bool is_append) const {
     ofs << static_cast<int64_t>(begin_timestamps_[i]) << ","
         << latency_micros_[i] << std::endl;
   }
+}
+
+double Timer::Min() const {
+  return *std::min_element(latency_micros_.begin(), latency_micros_.end());
+}
+double Timer::Max() const {
+  return *std::max_element(latency_micros_.begin(), latency_micros_.end());
 }
 
 Timer Timer::Merge(Timer& timer1, Timer& timer2) {

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -71,8 +71,8 @@ double Timer::TimeOpBegin() {
 void Timer::TimeOpEnd(int num_completed) {
   const double now = NowMicrosecs();
   CHECK(latency_micros_.size() == num_completed - 1);
-  CHECK(begin_timestamps_.size() == num_completed)
-      << begin_timestamps_.size() << " " << num_completed;
+  CHECK(begin_timestamps_.size() == num_completed) << begin_timestamps_.size()
+                                                   << " " << num_completed;
   latency_micros_.push_back(now - begin_timestamps_.back());
 }
 

--- a/src/timer.h
+++ b/src/timer.h
@@ -18,6 +18,8 @@ class Timer {
 
   void Stats(double* mean, double* std) const;
   std::string ReportStats(const std::string& name) const;
+  double Min() const;
+  double Max() const;
 
   void DropFirst(int n);
 

--- a/src/timer.h
+++ b/src/timer.h
@@ -6,8 +6,8 @@
 
 // For sequential queries only (i.e., launch next after current finishes).
 class Timer {
-public:
-  static Timer Merge(Timer &timer1, Timer &timer2);
+ public:
+  static Timer Merge(Timer& timer1, Timer& timer2);
   double NowMicrosecs() const;
 
   void ExpectOps(int N);
@@ -15,19 +15,19 @@ public:
   double TimeOpBegin();
   void TimeOpEnd(int num_completed);
 
-  void Stats(double *mean, double *std) const;
-  std::string ReportStats(const std::string &name) const;
+  void Stats(double* mean, double* std) const;
+  std::string ReportStats(const std::string& name) const;
 
   void DropFirst(int n);
 
-  void WriteToFile(const std::string &path) const;
+  void WriteToFile(const std::string& path) const;
 
-  std::vector<double> &begin_timestamps();
-  std::vector<double> &latency_micros();
+  std::vector<double>& begin_timestamps();
+  std::vector<double>& latency_micros();
 
-private:
+ private:
   std::vector<double> begin_timestamps_;
   std::vector<double> latency_micros_;
 };
 
-#endif // CREDIS_TIMER_
+#endif  // CREDIS_TIMER_

--- a/src/timer.h
+++ b/src/timer.h
@@ -2,6 +2,7 @@
 #define CREDIS_TIMER_
 
 #include <fstream>
+#include <iostream>
 #include <vector>
 
 // For sequential queries only (i.e., launch next after current finishes).
@@ -21,11 +22,14 @@ class Timer {
   void DropFirst(int n);
 
   void WriteToFile(const std::string& path) const;
+  void AppendToFile(const std::string& path) const;
 
   std::vector<double>& begin_timestamps();
   std::vector<double>& latency_micros();
 
  private:
+  void ToFile(const std::string& path, bool is_append) const;
+
   std::vector<double> begin_timestamps_;
   std::vector<double> latency_micros_;
 };

--- a/src/timer.h
+++ b/src/timer.h
@@ -1,12 +1,13 @@
 #ifndef CREDIS_TIMER_
 #define CREDIS_TIMER_
 
+#include <fstream>
 #include <vector>
 
 // For sequential queries only (i.e., launch next after current finishes).
 class Timer {
- public:
-  static Timer Merge(Timer& timer1, Timer& timer2);
+public:
+  static Timer Merge(Timer &timer1, Timer &timer2);
   double NowMicrosecs() const;
 
   void ExpectOps(int N);
@@ -14,15 +15,19 @@ class Timer {
   double TimeOpBegin();
   void TimeOpEnd(int num_completed);
 
-  void Stats(double* mean, double* std) const;
-  std::string ReportStats(const std::string& name) const;
+  void Stats(double *mean, double *std) const;
+  std::string ReportStats(const std::string &name) const;
 
-  std::vector<double>& begin_timestamps();
-  std::vector<double>& latency_micros();
+  void DropFirst(int n);
 
- private:
+  void WriteToFile(const std::string &path) const;
+
+  std::vector<double> &begin_timestamps();
+  std::vector<double> &latency_micros();
+
+private:
   std::vector<double> begin_timestamps_;
   std::vector<double> latency_micros_;
 };
 
-#endif  // CREDIS_TIMER_
+#endif // CREDIS_TIMER_


### PR DESCRIPTION
OSDI-era codebase.

Ran "./setup.sh; ./seqput.sh" on my Mac.

Scripts
- Scripts to perform distributed experiments where 2 chain nodes are placed on
  different instances, and master co-located with one instance.
- Script support to add/kill a chain node.

Server-side
- Lots of changes to support node-kill and node-add in a distributed setup.
- Node addition: implement faster batched state transfer (MemberNoPropBatchedPut
  as recv side, MemberReplicate as send side).

Client-side
- Lots of changes to support node-kill and node-add in a distributed setup.
- Significant updates to credis_seqput.bench.cc.  Better treatment of in-flight
  write and read.  Random fixed-size key-val pairs.  Significant retry logic to
  handle chain reconfiguration.  Tuning of various timers (have significant
  time-to-recovery consequences).

Misc
- Updated the leveldb submodule
- Better timer{.h,.cc} module
