### PR TITLE
Add virtual destructor to MasterClient

### DIFF
--- a/src/master_client.h
+++ b/src/master_client.h
@@ -25,6 +25,8 @@ class MasterClient {
     kSnFlushed = 1,
   };
 
+  virtual ~MasterClient {}
+
   virtual Status Connect(const std::string& address, int port) = 0;
 
   // TODO(zongheng): impl.


### PR DESCRIPTION
This avoids a gcc warning -Wdelete-non-virtual-dtor